### PR TITLE
Add more tests

### DIFF
--- a/modules/engine/lib/engine/jsonfill.js
+++ b/modules/engine/lib/engine/jsonfill.js
@@ -139,10 +139,12 @@ function project(columns, items) {
 // Given an item, filter it by column names, and attach the projected properties to the holder.
 function projectEach(item, columns) {
     // If columns have aliases, each row in the result set will be an object. If not, an array.
-    var holder = columns[0].alias ? {} : [];
+    var holder = columns[0].alias ? {} : [], name, flatten, obj;
     _.each(columns, function(column) {
         // Flatten results as the selector may include '..'
-        var obj = jsonPath.eval(item, column.name.trim(), {flatten: true});
+        name = column.name.trim();
+        flatten = name.indexOf('..') >= 0;
+        obj = jsonPath.eval(item, name, {flatten: flatten});
         if(obj == false) obj = undefined;
         if(obj && _.isArray(obj) && obj.length == 1) {
             obj = obj[0];

--- a/modules/engine/test/exec-find-all-test.js
+++ b/modules/engine/test/exec-find-all-test.js
@@ -15,7 +15,7 @@
  */
 
 var _ = require('underscore'),
-    Engine = require('lib/engine'),
+    Engine = require('../lib/engine'),
     EventEmitter = require('events').EventEmitter,
     sys = require('sys'),
     http = require('http'),
@@ -73,7 +73,8 @@ module.exports = {
 
                     test.equals(results.txb.length, 2);
                     test.equals(results.txs.length, 2);
-
+                    test.ok(results.be === undefined);
+                    test.ok(results.se === undefined);
                     test.done();
                 }
                 server.close();

--- a/modules/engine/test/exec-select-vs-ref-test.js
+++ b/modules/engine/test/exec-select-vs-ref-test.js
@@ -15,7 +15,7 @@
  */
 
 var _ = require('underscore'),
-    Engine = require('lib/engine'),
+    Engine = require('../lib/engine'),
     EventEmitter = require('events').EventEmitter,
     sys = require('sys'),
     http = require('http'),
@@ -57,7 +57,7 @@ module.exports = {
                     test.ok(_.isArray(results.be1));
                     test.ok(_.isUndefined(results.be1[0]));
                     test.ok(_.isUndefined(results.be2));
-                    test.deepEqual(results.me1[0], results.me2);
+                    test.deepEqual(results.me1[0][0], results.me2);
                     test.done();
                 }
                 server.close();

--- a/modules/engine/test/mock/find-all.ql
+++ b/modules/engine/test/mock/find-all.ql
@@ -22,10 +22,15 @@ ids = "{GetMultipleItemsResponse.$..ItemID}";
 txb = "{GetMyeBayBuyingResponse.$..OrderTransaction}";
 txs = "{GetMyeBaySellingResponse.$..OrderTransaction}";
 
+be = "{GetMyeBayBuyingResponse.Errors}";
+se = "{GetMyeBaySellingResponse.Errors}";
+
 return {
   "i1": "{i1}",
   "i2": "{GetMyeBaySellingResponse.$..ItemID}",
   "ids": "{ids}",
   "txb": "{txb}",
-  "txs": "{txs}"
+  "txs": "{txs}",
+  "be": "{be}",
+  "se": "{se}"
 }


### PR DESCRIPTION
Here is a summary of changes.
1. Some JS objects contain similar objects or arrays of objects at different levels. To select those objects, the script can use $.. selector. However, by default, JSONPath picks up those objects and arrays together and puts them in an array. The resulting array may look like
   
   [{obj}, [{obj}, {obj}, obj}], {obj}, ...]

The expected resut is

```
[obj, obj, obj, obj, obj, ...]
```

I updated JSONPath to add an option `flatten` to optionally concatenate the selected arrays to arrive at the expected result.
1. To avoid regressions on existing scripts, I'm making `flatten` an option that is triggered only when there is a `..` selector.
2. This change opened up one minor error in jsonfill when obj unwrapping is done (see the check obj.length == 1) check
3. Fixing (3) opened a bug in a test.
