### PR TITLE
Fix joins when column names use aliases

### DIFF
--- a/modules/compiler/lib/peg/ql.js
+++ b/modules/compiler/lib/peg/ql.js
@@ -7873,6 +7873,42 @@ module.exports = (function(){
 
 
 
+      // Reset the joiningColumn to the alias where columns are aliased
+
+      // The joining column is an index by default.
+
+      var joiningColumn;
+
+      if(main.columns[join.whereCriteria[0].rhs.joiningColumn].alias) {
+
+          for(var i = 0; i < main.columns.length; i++) {
+
+              if(main.columns[i].name === main.joiner.whereCriteria[0].rhs.value) {
+
+                  joiningColumn = main.columns[i].alias;
+
+                  break;
+
+              }
+
+          }
+
+          if(joiningColumn) {
+
+              main.joiner.whereCriteria[0].rhs.joiningColumn = joiningColumn;
+
+          }
+
+          else {
+
+              throw new this.SyntaxError("Line " + main.line + ": Joining column " + joiningColumn + " could not resolved. File a bug.");
+
+          }
+
+      }
+
+
+
       // Verify that all columns have prefixes
 
       for(var i = 0; i < main.columns.length; i++) {

--- a/modules/compiler/package.json
+++ b/modules/compiler/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-compiler",
-    "version": "0.2.11",
+    "version": "0.2.12",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/compiler/pegs/ql.peg
+++ b/modules/compiler/pegs/ql.peg
@@ -231,6 +231,24 @@
     }
     main.joiner = join;
 
+    // Reset the joiningColumn to the alias where columns are aliased
+    // The joining column is an index by default.
+    var joiningColumn;
+    if(main.columns[join.whereCriteria[0].rhs.joiningColumn].alias) {
+        for(var i = 0; i < main.columns.length; i++) {
+            if(main.columns[i].name === main.joiner.whereCriteria[0].rhs.value) {
+                joiningColumn = main.columns[i].alias;
+                break;
+            }
+        }
+        if(joiningColumn) {
+            main.joiner.whereCriteria[0].rhs.joiningColumn = joiningColumn;
+        }
+        else {
+            throw new this.SyntaxError("Line " + main.line + ": Joining column " + joiningColumn + " could not resolved. File a bug.");
+        }
+    }
+
     // Verify that all columns have prefixes
     for(var i = 0; i < main.columns.length; i++) {
         var prefixed = false;

--- a/modules/compiler/test/select-join-alias.js
+++ b/modules/compiler/test/select-join-alias.js
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2011 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var compiler = require('../lib/compiler'),
+    sys = require('sys');
+
+module.exports = {
+    'select-join-alias-remote': function(test) {
+        var q = 'select e.Title as title, e.ItemID as id, g.geometry.location as latlng, e.Location as loc from ebay.shopping.item as e, google.geocode as g where\
+                  e.itemId in (select itemId from ebay.finding.items where keywords = "mini")\
+                  and e.Location = g.address';
+        var cooked = compiler.compile(q);
+        test.equals(cooked[0].joiner.whereCriteria[0].rhs.type, 'alias');
+        test.equals(cooked[0].joiner.whereCriteria[0].rhs.value, 'e.Location');
+        test.equals(cooked[0].joiner.whereCriteria[0].rhs.joiningColumn, 'loc');
+        test.done();
+    },
+
+    'select-join-alias-local': function(test) {
+        var q = 'prodid = select ProductID[0].Value from ebay.shopping.products where QueryKeywords = "iphone" and siteid="0";\
+                 details = select * from ebay.shopping.productdetails where ProductID in ("{prodid}") and siteid=0 and ProductType = "Reference";\
+                 stats = select * from ebay.shopping.productstats where productID in ("{prodid}");\
+                return select d.ProductID[0].Value as id, d.Title as title, d.DetailsURL as details, d.ReviewCount as reviewCount, d.StockPhotoURL as photo,\
+        	        s.inventoryCountResponse as count\
+                    from details as d, stats as s where s.productId = d.ProductID[0].Value;';
+        var cooked = compiler.compile(q);
+        var statement = cooked[3].rhs;
+        test.equals(statement.joiner.whereCriteria[0].rhs.type, 'alias');
+        test.equals(statement.joiner.whereCriteria[0].rhs.value, 'd.ProductID[0].Value');
+        test.equals(statement.joiner.whereCriteria[0].rhs.joiningColumn, 'id');
+        test.done();
+    }
+}

--- a/modules/engine/lib/engine/select.js
+++ b/modules/engine/lib/engine/select.js
@@ -42,14 +42,7 @@ exports.exec = function(opts, statement, cb, parentEvent) {
         if(statement.joiner) {
             // Do the join now - we fill the joining column in into the joiner statement and execute it one for each
             // row from the main's results.
-
-            joiningColumn = statement.joiner.whereCriteria[0].rhs.joiningColumn
-            if(statement.columns[joiningColumn].alias) {
-                joiningColumn = statement.joiner.whereCriteria[0].rhs.value;
-                if(joiningColumn.indexOf(statement.fromClause[0].alias + '.') === 0) {
-                    joiningColumn = joiningColumn.substr(statement.fromClause[0].alias.length + 1);
-                }
-            }
+            joiningColumn = statement.joiner.whereCriteria[0].rhs.joiningColumn;
 
             // Prepare the joins
             funcs = [];

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.2.18",
+    "version": "0.2.19",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"


### PR DESCRIPTION
This fixes [Issue 52](https://github.com/ql-io/ql.io/issues/53).

This change includes the following changes
- When joining column is aliased, do a reverse look up on the main table's columns to find the alias name. This is because, by the time we come to execute joins, the main's resultset is already resolved to use alias names.
- Move this logic from exec time (select.js) to compile time (ql.peg) to save a few cycles.
- Add tests and update version numbers.
