### PR TITLE
ECV should be built after Console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MODULES	= modules/uri-template modules/mutable-uri modules/compiler modules/mon modules/engine \
-            modules/ecv modules/console
+          modules/console modules/ecv
 
 DIRS	= $(MODULES)
  

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MODULES	= modules/uri-template modules/mutable-uri modules/compiler modules/mon modules/engine \
-          modules/console modules/ecv
+          modules/console modules/ecv modules/app
 
 DIRS	= $(MODULES)
  

--- a/modules/console/public/css/console.css
+++ b/modules/console/public/css/console.css
@@ -192,3 +192,12 @@ div#trace-data table tbody tr td pre {
     opacity: 0.5;
     filter: alpha(opacity = 50); /* IE */
 }
+
+.red {
+    color: red;
+}
+
+.green {
+    color: green;
+}
+


### PR DESCRIPTION
I noticed this as the build failed the first time on a new demo VM. The order of build is incorrect.

This pull request also includes a couple of minor CSS changes.
