### PR TITLE
Add support block merging of responses.

### DIFF
--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.2.20",
+    "version": "0.2.21",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/test/exec-select-multi-req-merge.js
+++ b/modules/engine/test/exec-select-multi-req-merge.js
@@ -15,18 +15,22 @@
  */
 
 var _ = require('underscore'),
-    Engine = require('lib/engine'),
+    Engine = require('../lib/engine'),
+    http = require('http'),
+    util = require('util'),
+    url = require('url'),
+    fs = require('fs'),
     sys = require('sys');
 
 var engine = new Engine({
-    tables : __dirname + '/tables',
+    tables: __dirname + '/tables',
     config: __dirname + '/config/dev.json',
     connection: 'close'
 });
 
 // This tests merging of multiple HTTP requests
 module.exports = {
-    'check-merge': function(test) {
+    'check-merge-field': function (test) {
         var script = 'create table m1\
           on select get from "http://open.api.ebay.com/shopping?callname=GetMultipleItems&responseencoding={format}&appid={^apikey}&version={^version}&IncludeSelector=Details,ItemSpecifics,ShippingCosts&ItemID={20|itemId}"\
              using defaults format = "JSON",\
@@ -48,7 +52,7 @@ module.exports = {
         "mi2_1": "{mi2_1}",\
         "mi2_2": "{mi2_2}"\
         }';
-        engine.exec(script, function(err, result) {
+        engine.exec(script, function (err, result) {
             if(err) {
                 test.fail('got error: ' + err.stack || err);
                 test.done();
@@ -59,28 +63,72 @@ module.exports = {
                 test.ok(_.isArray(result.body.mi2_1));
                 test.ok(_.isArray(result.body.mi2_2[0]));
                 // Sort by ItemID
-                var l1 = _.sortBy(result.body.mi1, function(item) {
+                var l1 = _.sortBy(result.body.mi1, function (item) {
                     return item.ItemID;
                 });
-                var l2_1 = _.sortBy(result.body.mi2_1, function(item) {
+                var l2_1 = _.sortBy(result.body.mi2_1, function (item) {
                     return item.ItemID;
                 });
-                var l2_2 = _.sortBy(result.body.mi2_2[0], function(item) {
+                var l2_2 = _.sortBy(result.body.mi2_2[0], function (item) {
                     return item.ItemID;
                 });
-                var ids1 = _.map(l1, function(item) {
+                var ids1 = _.map(l1, function (item) {
                     return item.ItemID;
                 });
-                var ids2_1 = _.map(l2_1, function(item) {
+                var ids2_1 = _.map(l2_1, function (item) {
                     return item.ItemID;
                 });
-                var ids2_2 = _.map(l2_2, function(item) {
+                var ids2_2 = _.map(l2_2, function (item) {
                     return item.ItemID;
                 });
                 test.deepEqual(ids1, ids2_1);
                 test.deepEqual(ids1, ids2_2);
                 test.done();
             }
+        });
+    },
+
+    'check-merge-block': function (test) {
+        var server = http.createServer(function (req, res) {
+            var file = __dirname + '/mock' + req.url;
+            // Remove query params
+            var parsed = url.parse(file, true);
+            file = parsed.pathname;
+            var stat = fs.statSync(file);
+            res.writeHead(200, {
+                'Content-Type': file.indexOf('.xml') >= 0 ? 'application/xml' : 'application/json',
+                'Content-Length': stat.size
+            });
+            var readStream = fs.createReadStream(file);
+            util.pump(readStream, res, function (e) {
+                if(e) {
+                    console.log(e.stack || e);
+                }
+                res.end();
+            });
+        });
+        server.listen(3000, function () {
+            // Do the test here.
+            var engine = new Engine({
+                connection: 'close'
+            });
+            var script = fs.readFileSync(__dirname + '/mock/merge-block.ql', 'UTF-8');
+            engine.exec(script, function (err, results) {
+                if(err) {
+                    console.log(err.stack || err);
+                    test.ok(false, 'Grrr');
+                    test.done();
+                }
+                else {
+                    results = results.body;
+                    test.ok(_.isArray(results));
+                    _.each(results, function(item) {
+                        test.equals(item.ProductID.Value, 99700122);
+                    });
+                    server.close();
+                    test.done();
+                }
+            });
         });
     }
 }

--- a/modules/engine/test/mock/ProductReviews-Merge-Block.json
+++ b/modules/engine/test/mock/ProductReviews-Merge-Block.json
@@ -1,0 +1,51 @@
+{"Timestamp": "2011-11-07T16:14:22.892Z", "Ack": "Success", "Build": "E745_CORE_BUNDLED_14025482_R1", "Version": "745", "ReviewCount": 16, "BuyingGuideCount": 0, "ProductID": {
+    "Value": "99700122",
+    "Type": "Reference"
+}, "ReviewsAndGuidesURL": "http://search.reviews.ebay.com/Apple-MacBook-Pro-15-4-Laptop-MC721LL-A-February-2011?fvcs=1853&sopr=99700122&upvr=2", "PageNumber": 1, "TotalPages": 4, "BuyingGuideDetails": {
+    "BuyingGuide": [],
+    "BuyingGuideHub": "http://search.reviews.ebay.com/?satitle=Apple+MacBook+Pro+15.4%22+Laptop+-+MC721LL%2FA+%28February%2C+2011%29&uqt=g"
+}, "ReviewDetails": {
+    "AverageRating": 4.5,
+    "Review": [
+        {
+            "URL": "http://search.reviews.ebay.com/Apple-MacBook-Pro-15-4-Laptop-MC721LL-A-February-2011?fvcs=1853&sopr=99700122&upvr=2",
+            "Title": "A Powerhouse leader in performance and functionality",
+            "Rating": 5,
+            "Text": "I have been a PC user for a long time and now understand and appreciate the power of a Mac. There is no substitute, and the price is totally worth it!",
+            "UserID": "beefboy4707",
+            "CreationTime": "2011-09-29T20:48:14.000Z"
+        },
+        {
+            "URL": "http://search.reviews.ebay.com/Apple-MacBook-Pro-15-4-Laptop-MC721LL-A-February-2011?fvcs=1853&sopr=99700122&upvr=2",
+            "Title": "Neither bad, nor good",
+            "Rating": 1,
+            "Text": "The given product yet hasn't received, therefore a withdrawal I can not constitute. As soon as I will test this model, I will necessarily leave the withdrawal. Thanks",
+            "UserID": "viktor_mislivets",
+            "CreationTime": "2011-10-10T16:03:59.000Z"
+        },
+        {
+            "URL": "http://search.reviews.ebay.com/Apple-MacBook-Pro-15-4-Laptop-MC721LL-A-February-2011?fvcs=1853&sopr=99700122&upvr=2",
+            "Title": "Perfect and superior product no regrets.",
+            "Rating": 5,
+            "Text": "Just perfect, this item was brand new sealed in original packaging never opened never used and the price was significantly better than in the stores. I have been shopping on ebay for a long time and this is one of the best deals I have had. I am totally satisfied with this purchase. After this purchase I may never go back to windows. Congrats to the seller A++++++++ and highly recommended",
+            "UserID": "cassiusmills",
+            "CreationTime": "2011-10-29T16:24:00.000Z"
+        },
+        {
+            "URL": "http://search.reviews.ebay.com/Apple-MacBook-Pro-15-4-Laptop-MC721LL-A-February-2011?fvcs=1853&sopr=99700122&upvr=2",
+            "Title": "Tremendous product, great value.",
+            "Rating": 5,
+            "Text": "Bought this computer as i needed to upgrade from the Power PC computer i had in order to use upgraded software.  The MacBook Pro delivered as advertised in terms of speed and performance.\r\n\r\nOnly problem was that when purchasing the Apple Care warranty, it only was three months short of the promised 3 year coverage.  The seller claims they will stand behind the product for the final 3 months.",
+            "UserID": "impdas",
+            "CreationTime": "2011-10-11T17:35:14.000Z"
+        },
+        {
+            "URL": "http://search.reviews.ebay.com/Apple-MacBook-Pro-15-4-Laptop-MC721LL-A-February-2011?fvcs=1853&sopr=99700122&upvr=2",
+            "Title": "A MUST buy for any multimedia or recording.",
+            "Rating": 4,
+            "Text": "Best computer buy I've made in years. \r\n\r\nAlways have bought HP and Windows applications. Mostly because I was familiar with the operating system and knew my ins and outs. After about a day playing around with the Macbook Pro, I feel pretty proficient. I switched over to Apple for Music and other multimedia applications.\r\n\r\n\r\nWish I bought one sooner. Certainly worth the money and could have saved me thousands in the long run.",
+            "UserID": "dethdrummer",
+            "CreationTime": "2011-10-04T12:14:24.000Z"
+        }
+    ]
+}}

--- a/modules/engine/test/mock/merge-block.ql
+++ b/modules/engine/test/mock/merge-block.ql
@@ -1,0 +1,5 @@
+
+create table ebay.ProductReviews
+  on select get from "http://localhost:3000/ProductReviews-Merge-Block.json?ProductID.Value={#ProductID}"
+
+return select * from ebay.ProductReviews where ProductID in ('99700122', '99700122', '99700122', '99700122', '99700122');

--- a/modules/uri-template/lib/uri-template.js
+++ b/modules/uri-template/lib/uri-template.js
@@ -11,6 +11,7 @@ module.exports = (function(){
     parse: function(input, startRule) {
       var parseFunctions = {
         "URITemplate": parse_URITemplate,
+        "blockMerge": parse_blockMerge,
         "digits": parse_digits,
         "expression": parse_expression,
         "literal": parse_literal,
@@ -234,6 +235,14 @@ module.exports = (function(){
                       var str = '', i, j, val, split = false, arr;
                       return _format('', values, defaults);
                   },
+                  merge: function() {
+                      for(i = 0; i < o.length; i++) {
+                          if(o[i].merge) {
+                              return o[i].merge;
+                          }
+                      }
+                      return 'field';
+                  },
                   stream: o
               }
           })(result1)
@@ -379,15 +388,20 @@ module.exports = (function(){
         }
 
 
-        var result2 = parse_required();
-        if (result2 !== null) {
-          var result0 = result2;
+        var result3 = parse_required();
+        if (result3 !== null) {
+          var result0 = result3;
         } else {
-          var result1 = parse_multivalued();
-          if (result1 !== null) {
-            var result0 = result1;
+          var result2 = parse_blockMerge();
+          if (result2 !== null) {
+            var result0 = result2;
           } else {
-            var result0 = null;;
+            var result1 = parse_multivalued();
+            if (result1 !== null) {
+              var result0 = result1;
+            } else {
+              var result0 = null;;
+            };
           };
         }
 
@@ -422,7 +436,49 @@ module.exports = (function(){
         var result2 = result1 !== null
           ? (function() {
               return {
-                required: true
+                  required: true
+              }
+          })()
+          : null;
+        if (result2 !== null) {
+          var result0 = result2;
+        } else {
+          var result0 = null;
+          pos = savedPos0;
+        }
+
+
+
+        cache[cacheKey] = {
+          nextPos: pos,
+          result:  result0
+        };
+        return result0;
+      }
+
+      function parse_blockMerge() {
+        var cacheKey = 'blockMerge@' + pos;
+        var cachedResult = cache[cacheKey];
+        if (cachedResult) {
+          pos = cachedResult.nextPos;
+          return cachedResult.result;
+        }
+
+
+        var savedPos0 = pos;
+        if (input.substr(pos, 1) === "#") {
+          var result1 = "#";
+          pos += 1;
+        } else {
+          var result1 = null;
+          if (reportMatchFailures) {
+            matchFailed("\"#\"");
+          }
+        }
+        var result2 = result1 !== null
+          ? (function() {
+              return {
+                  merge: 'block'
               }
           })()
           : null;
@@ -478,7 +534,7 @@ module.exports = (function(){
         var result2 = result1 !== null
           ? (function(d) {
               var ret = {
-                multivalued: true
+                  multivalued: true
               }
               d = parseInt(d);
               if(d > 0) {

--- a/modules/uri-template/package.json
+++ b/modules/uri-template/package.json
@@ -2,7 +2,7 @@
     "author": "ql.io",
     "description": "A small URI template processor for ql.io.",
     "name": "ql.io-uri-template",
-    "version": "0.2.8",
+    "version": "0.2.9",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/uri-template/peg/uri-template.peg
+++ b/modules/uri-template/peg/uri-template.peg
@@ -125,6 +125,14 @@ URITemplate  = c:( literal / expression )* {
             var str = '', i, j, val, split = false, arr;
             return _format('', values, defaults);
         },
+        merge: function() {
+            for(i = 0; i < o.length; i++) {
+                if(o[i].merge) {
+                    return o[i].merge;
+                }
+            }
+            return 'field';
+        },
         stream: o
     }
 }
@@ -148,17 +156,23 @@ expression =  "{" op:operator* v:variable "}" {
     return token;
 }
 
-operator = required / multivalued
+operator = required / blockMerge / multivalued
 
 required = '^' {
     return {
-      required: true
+        required: true
+    }
+}
+
+blockMerge = '#' {
+    return {
+        merge: 'block'
     }
 }
 
 multivalued = d:digits? '|' {
     var ret = {
-      multivalued: true
+        multivalued: true
     }
     d = parseInt(d);
     if(d > 0) {

--- a/modules/uri-template/test/uri-template-test.js
+++ b/modules/uri-template/test/uri-template-test.js
@@ -275,5 +275,15 @@ module.exports = {
         });
         test.equals(uri, 'http://www.foo.com?p1=this%20is%20a%20value&p2=this%2Bis%2Ba%2Bvalue&p3=this%2Fis%2Fanother%2Fvalue');
         test.done();
+    },
+
+    'merge': function(test) {
+        var str = "http://www.foo.com?p1={p1}&p2={p2}&p3={#p3}";
+        var template = uriTemplate.parse(str);
+        test.equals(template.merge(), 'block');
+        str = "http://www.foo.com?p1={p1}&p2={p2}&p3={p3}";
+        template = uriTemplate.parse(str);
+        test.ok(template.merge(), 'field');
+        test.done();
     }
 };


### PR DESCRIPTION
This change applies for tables that take one value for the primary param,
but the script is feeding in multiple values for that param.

Consider the URL for the table:

```
http://foo.com?param={param}
```

used with a select

```
select * from foo where param in ('1', '2', '3')
```

In this case, we make three requests to the URL, and merge the results field
by field.

Imagine that the response for each request looks like this

```
{'t': 't1',
  'status': 'ok',
  'result': {
    'id': '1',
    'b': 'b1'
  }
}
```

By default, we merge the three responses field by field resulting in

```
{'t': ['t1','t2','t3'],
  'status': ['ok','ok','ok'],
  'result': [{
    'id': '1',
    'b': 'b1'
  },
  {
    'id': '2',
    'b': 'b2'
  },
  {
    'id': '3',
    'b': 'b3'
  }
}
```

This makes sense for some APIs. Consider a different style of response.

```
{
  'id': '1',
  'b': 'b1'
}
```

In this case, merging the results into an array is more useful.

```
[{
    'id': '1',
    'b': 'b1'
  },
  {
    'id': '2',
    'b': 'b2'
  },
  {
    'id': '3',
    'b': 'b3'
  }
]
```

The table can indicate which behavior it wants by prepending '#'. This triggers "block merging".

```
http://foo.com?param={#param}
```

This change implements this variant. The example on http://ql.io also depends on
this fix.
