### PR TITLE
Issue 66: Proxy URIs can be configured for individual URIs in the config.  

### DIFF
--- a/modules/engine/lib/engine/http.request.js
+++ b/modules/engine/lib/engine/http.request.js
@@ -295,10 +295,21 @@ function sendOneRequest(args, resourceUri, params, holder, cb) {
     assert.ok(port, 'Port of URI [' + resourceUri + '] is invalid')
     path = (heirpart.path().value || '') + (uri.querystring() || '');
 
-    if(globalOpts && globalOpts.config && globalOpts.config.proxy) {
-        useProxy = true;
-        proxyHost = globalOpts.config.proxy.host;
-        proxyPort = globalOpts.config.proxy.port;
+    if (globalOpts && globalOpts.config && globalOpts.config.proxy) {
+        var proxyConfig = globalOpts.config.proxy;
+        if (proxyConfig[host] && !proxyConfig[host].host) {
+            useProxy = false;
+        }
+        else if (proxyConfig[host] && proxyConfig[host].host) {
+            proxyHost = proxyConfig[host].host;
+            proxyPort = proxyConfig[host].port;
+            useProxy = true;
+        }
+        else if (proxyConfig['*']) {
+            proxyHost = proxyConfig['*'].host;
+            proxyPort = proxyConfig['*'].port;
+            useProxy = true;
+        }
     }
 
     options = {

--- a/modules/engine/test/config/proxy.json
+++ b/modules/engine/test/config/proxy.json
@@ -1,0 +1,18 @@
+{
+    "proxy":{
+        "open.api.ebay.com":{
+            "host":"ne.vip.ebay.com",
+            "port":"80"
+        },
+        "*" : {
+            "host":"unknown.vip.ebay.com",
+            "port":"80"
+        },
+        "svcs.ebay.com" : {
+
+        }
+    },
+    "ebay":{
+        "apikey":"Qlio1a92e-fea5-485d-bcdb-1140ee96527"
+    }
+}

--- a/modules/engine/test/proxy-test.js
+++ b/modules/engine/test/proxy-test.js
@@ -1,0 +1,92 @@
+/**
+ /*
+  * Copyright 2011 eBay Software Foundation
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License");
+  * you may not use this file except in compliance with the License.
+  * You may obtain a copy of the License at
+  *
+  *    http://www.apache.org/licenses/LICENSE-2.0
+  *
+  * Unless required by applicable law or agreed to in writing, software
+  * distributed under the License is distributed on an "AS IS" BASIS,
+  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  * See the License for the specific language governing permissions and
+  * limitations under the License.
+  */
+"use strict"
+
+var _ = require('underscore'),
+    Engine = require('lib/engine'),
+    sys = require('sys'),
+    EventEmitter = require('events').EventEmitter();
+
+
+var logger = require('winston');
+logger.remove(logger.transports.Console);
+logger.add(logger.transports.Console, {level:'error'});
+
+var engine = new Engine({
+    tables:__dirname + '/tables',
+    config:__dirname + '/config/proxy.json',
+    connection:'close'
+});
+
+module.exports = {
+
+    'select-without-proxy':function (test) {
+        var q;
+        q = 'select * from ebay.finding.items where keywords = "ipad"';
+        engine.exec(q, function (err, list) {
+            if (err) {
+                test.fail('got error: ' + err.stack || err);
+                test.done();
+            }
+            else {
+
+                test.equals(list.headers['content-type'], 'application/json', 'HTML expected');
+                test.ok(_.isArray(list.body), 'expected an array');
+                test.ok(list.body.length > 0, 'expected some items');
+                test.ok(!_.isArray(list.body[0]), 'expected object in the array');
+                test.done();
+            }
+        });
+    },
+
+    'test-star':function (test) {
+        var q = "select * from google.shopping where barcode = '09780802453792'";
+        try {
+            engine.exec(q, function (err) {
+                if (err) {
+                    test.ok(true);
+                }
+                else {
+                    test.fail("should not pass as the proxy used is non existent");
+                }
+            });
+        }
+        catch (err) {
+
+        }
+        test.done();
+
+    },
+
+    'select-with-proxy':function (test) {
+        var q = "select Location from ebay.shopping.item where itemId in (select itemId from ebay.finding.items where keywords='ipad')"
+        try {
+            engine.exec(q, function (err) {
+                if (err) {
+                    test.ok(true);
+                }
+                else {
+                    test.fail("should not pass as the proxy used is non existent");
+                }
+            });
+        }
+        catch (err) {
+
+        }
+        test.done();
+    }
+}


### PR DESCRIPTION
Proxy URIs can be configured for individual URIs in the config. 

Example configuration:

"proxy":{
        "open.api.ebay.com":{
            "host":"ne.vip.ebay.com",
            "port":"80"
        },
        "*" : {
            "host":"unknown.vip.ebay.com",
            "port":"80"
        },
        "svcs.ebay.com" : {

```
    }
}
```

The above config instructs engine to use "unknown.vip.ebay.com:80" for all the outgoing calls except "open.api.ebay.com" (for which use ne.vip.ebay.com:80 as proxy) and svc.ebay.com (no proxy).
