### PR TITLE
Enable non-WebSocket browsers

### DIFF
--- a/modules/console/app.js
+++ b/modules/console/app.js
@@ -304,6 +304,10 @@ var Console = module.exports = function(config) {
                         events.push(event);
                     })
                 }
+                connection.sendUTF(JSON.stringify({
+                    type: 'events',
+                    data: '{}'
+                }));
             }
             else if (event.type === 'script') {
                 emitter = new EventEmitter();

--- a/modules/console/package.json
+++ b/modules/console/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-console",
-    "version": "0.2.12",
+    "version": "0.2.13",
     "repository": {
         "type": "git",
         "url": "ssh://gitolite@crpgit.corp.ebay.com/ql.io.git"

--- a/modules/console/public/views/console/index.ejs
+++ b/modules/console/public/views/console/index.ejs
@@ -59,7 +59,6 @@
 <div id="query">
     <textarea class="query-input" id="query-input"><%=script%></textarea>
 </div>
-<div><span id="ua-advice">Use latest versions of Firefox or Chrome.</span></div>
 
 <div>
     <div class="parse-status" id="parse-status"></div>

--- a/modules/engine/lib/engine/http.request.js
+++ b/modules/engine/lib/engine/http.request.js
@@ -36,10 +36,11 @@ var strTemplate = require('./peg/str-template.js'),
     os = require('os');
 
 exports.exec = function(args) {
-    var request, resource, statement, params, resourceUri, template, cb, holder,
+    var request, context, resource, statement, params, resourceUri, template, cb, holder,
         validator, parentEvent, emitter, tasks, globalOpts, merge;
 
     resource = args.resource;
+    context = args.context;
     request = args.request; // headers and params extracted from an incoming request (if any)
     statement = args.statement;
     cb = args.callback;
@@ -55,6 +56,9 @@ exports.exec = function(args) {
         request.routeParams,
         request.body,
         args.params);
+    if(context) {
+        params.__proto__ = context;
+    }
 
     // Validate all params
     if(resource.monkeyPatch && resource.monkeyPatch['validate param']) {

--- a/modules/engine/lib/engine/insert.js
+++ b/modules/engine/lib/engine/insert.js
@@ -55,6 +55,7 @@ exports.exec = function(opts, statement, cb, parentEvent) {
     });
 
     httpRequest.exec({
+        context: opts.context,
         resource: table.insert,
         params: values,
         request: request,

--- a/modules/engine/lib/engine/select.js
+++ b/modules/engine/lib/engine/select.js
@@ -271,6 +271,7 @@ function execInternal(opts, statement, cb, parentEvent) {
                     params[offset] = statement.offset;
 
                     httpRequest.exec({
+                        context: opts.context,
                         resource: resource.select,
                         params: params,
                         request: request,

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.2.25",
+    "version": "0.2.26",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/test/exec-scatter-test.js
+++ b/modules/engine/test/exec-scatter-test.js
@@ -30,7 +30,7 @@ var engine = new Engine({
 });
 
 module.exports = {
-    'select-star': function(test) {
+    'select-times': function(test) {
         var q;
         q = 'select * from scatter where keywords = "ipad"';
         engine.exec(q, function(err, list) {
@@ -44,6 +44,30 @@ module.exports = {
                 test.ok(_.isArray(list.body), 'expected an array');
                 test.equals(list.body.length, 30, 'expected 30 items since we scatter three requests');
                 test.done();
+            }
+        });
+    },
+
+    'select-context-lookup': function(test) {
+        var q;
+        q = 'select * from scatter where keywords = "ipad"';
+        engine.exec({
+            context: {
+                times: 2
+            },
+            script: q,
+            cb : function(err, list) {
+                if(err) {
+                    console.log(err.stack || err);
+                    test.fail('got error: ' + err.stack || err);
+                    test.done();
+                }
+                else {
+                    test.equals(list.headers['content-type'], 'application/json', 'HTML expected');
+                    test.ok(_.isArray(list.body), 'expected an array');
+                    test.equals(list.body.length, 20, 'expected 20 items since we scatter three requests');
+                    test.done();
+                }
             }
         });
     }

--- a/modules/engine/test/tables/scatter.js
+++ b/modules/engine/test/tables/scatter.js
@@ -1,3 +1,8 @@
 exports['patch uri'] = function(args) {
-    return [args.uri, args.uri, args.uri];
+    var arr = [];
+    var times = args.params.times || 3;
+    for(var i = 0; i < times; i++) {
+        arr.push(args.uri);
+    }
+    return arr;
 }


### PR DESCRIPTION
This is a long-overdue item. This pull request tries to send a probe message to the server using WebSocket protocol, and only on success/failure decides to use WebSocket or XHR. Consequently, ql.io can gracefully deal with browsers other than Chrome and Firefox.
