### PR TITLE
Issue 76 Fix - Request-Id population

### DIFF
--- a/modules/engine/lib/engine/http.request.js
+++ b/modules/engine/lib/engine/http.request.js
@@ -369,8 +369,14 @@ function sendOneRequest(args, resourceUri, params, holder, cb) {
                 })
                 emitter.emit(eventTypes.STATEMENT_RESPONSE, packet);
 
-                if(res.headers[requestId.name])  {
-                   emitter.emit(eventTypes.REQUEST_ID_RECEIVED, res.headers[requestId.name]);
+                if (res.headers[requestId.name]) {
+                    emitter.emit(eventTypes.REQUEST_ID_RECEIVED, res.headers[requestId.name]);
+                }
+                else {
+                    // Send back the uuid created in ql.io, if the underlying api
+                    // doesn't support the request tracing or the table is not configured with
+                    // the right name of the header.
+                    emitter.emit(eventTypes.REQUEST_ID_RECEIVED, h[requestId.name]);
                 }
             }
 

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.2.26",
+    "version": "0.2.27",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/test/request-id-test.js
+++ b/modules/engine/test/request-id-test.js
@@ -27,37 +27,38 @@ var engine = new Engine({
 module.exports = {
     'mint-request-id': function(test) {
         var script = "create table header.replace\n\
-            on select get from 'http://svcs.ebay.com/services/search/FindingService/v1?OPERATION-NAME=findItemsByKeywords&SERVICE-VERSION=1.8.0&GLOBAL-ID={globalid}&SECURITY-APPNAME={apikey}&RESPONSE-DATA-FORMAT={format}&REST-PAYLOAD&keywords={^keywords}&paginationInput.entriesPerPage={limit}&paginationInput.pageNumber={pageNumber}&outputSelector%280%29=SellerInfo&sortOrder={sortOrder}'\n\
-                 with aliases format = 'RESPONSE-DATA-FORMAT', json = 'JSON', xml = 'XML'\n\
-                 using defaults format = 'JSON', globalid = 'EBAY-US', sortorder ='BestMatch',\n\
-                       apikey =  '{config.ebay.apikey}', limit = 10,\n\
-                       pageNumber = 1\n\
-                 resultset 'findItemsByKeywordsResponse.searchResult.item'\n\
-            select * from header.replace where keywords = 'ferrari' limit 1";
-        var emitter = new EventEmitter();
-        var headers;
-        emitter.on(Engine.Events.STATEMENT_REQUEST, function(v) {
-            headers = v.headers;
-        });
-        engine.exec({
-            script: script,
-            emitter: emitter,
-            cb: function(err, result) {
-                if (err) {
-                    console.log(err.stack || err);
-                    test.ok(false);
-                }
-                else {
-                    var reqId = _.detect(headers, function(v) {
-                        return v.name == 'request-id'
-                    });
-                    test.ok(reqId && reqId.value);
-                }
-                test.done();
-            }
-        });
+                   on select get from 'http://svcs.ebay.com/services/search/FindingService/v1?OPERATION-NAME=findItemsByKeywords&SERVICE-VERSION=1.8.0&GLOBAL-ID={globalid}&SECURITY-APPNAME={apikey}&RESPONSE-DATA-FORMAT={format}&REST-PAYLOAD&keywords={^keywords}&paginationInput.entriesPerPage={limit}&paginationInput.pageNumber={pageNumber}&outputSelector%280%29=SellerInfo&sortOrder={sortOrder}'\n\
+                        with aliases format = 'RESPONSE-DATA-FORMAT', json = 'JSON', xml = 'XML'\n\
+                        using defaults format = 'JSON', globalid = 'EBAY-US', sortorder ='BestMatch',\n\
+                              apikey =  '{config.ebay.apikey}', limit = 10,\n\
+                              pageNumber = 1\n\
+                        resultset 'findItemsByKeywordsResponse.searchResult.item'\n\
+                   select * from header.replace where keywords = 'ferrari' limit 1";
+           var emitter = new EventEmitter();
+           var headers;
+           emitter.on(Engine.Events.STATEMENT_REQUEST, function(v) {
+               headers = v.headers;
+           });
+           engine.exec({
+               script: script,
+               emitter: emitter,
+               cb: function(err, result) {
+                   if (err) {
+                       console.log(err.stack || err);
+                       test.ok(false);
+                   }
+                   else {
+                       var reqId = _.detect(headers, function(v) {
+                           return v.name == 'request-id'
+                       });
+                       test.ok(reqId && reqId.value);
+                       test.ok(result.headers["request-id"]);
+                       test.ok(reqId.value+']' === result.headers["request-id"]);
+                   }
+                   test.done();
+               }
+           });
     },
-
     'incoming-request-id-from-ddl': function(test) {
         var script = "create table header.replace\n\
             on select get from 'http://svcs.ebay.com/services/search/FindingService/v1?OPERATION-NAME=findItemsByKeywords&SERVICE-VERSION=1.8.0&GLOBAL-ID={globalid}&SECURITY-APPNAME={apikey}&RESPONSE-DATA-FORMAT={format}&REST-PAYLOAD&keywords={^keywords}&paginationInput.entriesPerPage={limit}&paginationInput.pageNumber={pageNumber}&outputSelector%280%29=SellerInfo&sortOrder={sortOrder}'\n\


### PR DESCRIPTION
Engine sends back the uuid created in ql.io, if the underlying api doesn't
support the request tracing or the table is not
configured with the right request-id header.
