### PR TITLE
Join failure when the main statement has just one field 

### DIFF
--- a/modules/engine/lib/engine/select.js
+++ b/modules/engine/lib/engine/select.js
@@ -51,7 +51,7 @@ exports.exec = function(opts, statement, cb, parentEvent) {
                 cloned = clone(statement.joiner);
 
                 // Set the join field
-                cloned.whereCriteria[0].rhs.value = row[joiningColumn];
+                cloned.whereCriteria[0].rhs.value = (_.isArray(row) || _.isObject(row)) ? row[joiningColumn] : row;
 
                 funcs.push(function(s) {
                     return function(callback) {

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/test/exec-select-join-test.js
+++ b/modules/engine/test/exec-select-join-test.js
@@ -174,6 +174,23 @@ module.exports = {
                 test.done();
             }
         });
-    }
+    },
 
+    'select-join-single-col': function(test) {
+        var q = 'select e.ItemID, e.Title, e.ViewItemURLForNaturalSearch from ebay.finding.items as f, ebay.shopping.item as e\
+                 where e.itemId = f.itemId and f.keywords="mini cooper";';
+
+       engine.exec(q, function(err, list) {
+           if(err) {
+               test.fail('got error: ' + err.stack || err);
+               test.done();
+           }
+           else {
+               test.equals(list.headers['content-type'], 'application/json', 'JSON expected');
+               test.ok(_.isArray(list.body), 'expected an array');
+               test.equals(10, list.body.length, 'expected 10 items');
+               test.done();
+           }
+       });
+    }
 }


### PR DESCRIPTION
The look for joining field fails when there is only a single value in the result of the main statement.

Thanks to Erik Paulson for giving a test case.

select e.ItemID, e.Title, e.ViewItemURLForNaturalSearch 
from finditems as f, details as e, 
where e.itemID = f.itemID and f.keywords="mini cooper";
