### PR TITLE
Simple Fix

### DIFF
--- a/modules/engine/lib/engine/insert.js
+++ b/modules/engine/lib/engine/insert.js
@@ -57,6 +57,7 @@ exports.exec = function(opts, statement, cb, parentEvent) {
     httpRequest.exec({
         context: opts.context,
         resource: table.insert,
+        xformers: opts.xformers,
         params: values,
         request: request,
         statement: statement,


### PR DESCRIPTION
insert's exec was not passing the xformers to the http.request.
Now the parameter is passed correctly.
