### PR TITLE
Support recursive templating

### DIFF
--- a/modules/engine/lib/engine/peg/str-template.js
+++ b/modules/engine/lib/engine/peg/str-template.js
@@ -137,6 +137,10 @@ module.exports = (function(){
                       current++;
                   }
               }
+              var tokenCount = 0;
+              for(i = 0; i < c.length; i++) {
+                if(c[i].variable) tokenCount++;
+              }
               return {
                   format: function(bag, keep) {
                       var str = '', i, j, ref, current;
@@ -163,7 +167,8 @@ module.exports = (function(){
                       }
                       return str;
                   },
-                  stream: o
+                  stream: o,
+                  tokenCount: tokenCount
               }
           })(result1)
           : null;

--- a/modules/engine/lib/engine/recursive-str-template.js
+++ b/modules/engine/lib/engine/recursive-str-template.js
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2011 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var strTemplate = require('./peg/str-template.js');
+
+exports.format = function(template, bag, keep) {
+
+    var str = template, parsed;
+    parsed = strTemplate.parse(str);
+    while(parsed.tokenCount > 0) {
+        str = parsed.format(bag, keep);
+        parsed = strTemplate.parse(str);
+    }
+    return str;
+}
+

--- a/modules/engine/pegs/str-template.peg
+++ b/modules/engine/pegs/str-template.peg
@@ -63,6 +63,10 @@ template  = c:( expression / literal )* {
             current++;
         }
     }
+    var tokenCount = 0;
+    for(i = 0; i < c.length; i++) {
+      if(c[i].variable) tokenCount++;
+    }
     return {
         format: function(bag, keep) {
             var str = '', i, j, ref, current;
@@ -87,9 +91,15 @@ template  = c:( expression / literal )* {
                     }
                 }
             }
+            var ss = parse(str);
+            if(ss.tokenCount > 0) {
+                str = ss.format(bag, keep);
+                ss = parse(str);
+            }
             return str;
         },
-        stream: o
+        stream: o,
+        tokenCount: tokenCount
     }
 }
 

--- a/modules/uri-template/lib/uri-template.js
+++ b/modules/uri-template/lib/uri-template.js
@@ -138,6 +138,22 @@ module.exports = (function(){
                       current++;
                   }
               }
+              function select(path, obj) {
+                  var splits = !path ? [] : path.split('.');
+                  var curr = obj;
+                  for(var i = 0; i < splits.length; i++) {
+                      if(curr[splits[i]]) {
+                          curr = curr[splits[i]];
+                          if(i < splits.length - 1 && curr.constructor === Array && curr.length > 0) {
+                              curr = curr[0];
+                          }
+                      }
+                      else {
+                          return null;
+                      }
+                  }
+                  return curr;
+              }
               function _append(str, val, encode) {
                   var j;
                   if(str.constructor === Array) {
@@ -150,80 +166,91 @@ module.exports = (function(){
                   }
                   return str;
               }
-              function _format(str, values, defaults) {
+              function _format(str, values, defaults, stream) {
                   values = values || {};
                   defaults = defaults || {};
-                  var i, j, val, split = false, arr, subset;
-                  for(i = 0; i < o.length; i++) {
-                      if(o[i].constructor === String) {
-                          str = _append(str, o[i], false);
+                  var i, j, val, split = false, arr, subset, key;
+                  stream = stream || o;
+                  var ele;
+                  for(i = 0; i < stream.length; i++) {
+                      ele = stream[i];
+                      if(ele.constructor === String) {
+                          str = _append(str, ele, false);
                       }
                       else {
-                          val = values[o[i].variable] || defaults[o[i].variable];
-                          if(val) {
-                              if(val.constructor == Array) {
-                                  // But is the token multivalued?
-                                  if(val.length === 1) {
-                                      str = _append(str, val, true);
-                                  }
-                                  else if(o[i].multivalued) {
-                                      if(o[i].max) {
-                                          if(val.length <= o[i].max) {
-                                              // Append as usual
-                                              str = _append(str, val, true);
-                                          }
-                                          else {
-                                              // Split the values into multiple and append each
-                                              if(split) {
-                                                  throw {
-                                                      error: 'Template can not have multiple single-valued params with multiple values'
-                                                  }
+                          if(ele.variable.constructor == Array) {
+                              // Case of nested token - only single valued for now
+                              key = _format('', values, defaults, ele.variable);
+                              val = select(key, values) || select(key, defaults);
+                              str = str + val;
+                          }
+                          else {
+                              val = select(ele.variable, values) || select(ele.variable, defaults);
+                              if(val) {
+                                  if(val.constructor == Array) {
+                                      // But is the token multivalued?
+                                      if(val.length === 1) {
+                                          str = _append(str, val, true);
+                                      }
+                                      else if(ele.multivalued) {
+                                          if(ele.max) {
+                                              if(val.length <= ele.max) {
+                                                  // Append as usual
+                                                  str = _append(str, val, true);
                                               }
                                               else {
-                                                  split = true;
-                                                  // Split and continue.
-                                                  arr = [];
-                                                  subset = [];
-                                                  var start = 0, end = o[i].max;
-                                                  for(j = 0; j < val.length/o[i].max; j++) {
-                                                      subset = val.slice(start, end);
-                                                      arr.push(_append(str, subset, true));
-                                                      start += o[i].max;
-                                                      end += o[i].max;
+                                                  // Split the values into multiple and append each
+                                                  if(split) {
+                                                      throw {
+                                                          error: 'Template can not have multiple single-valued params with multiple values'
+                                                      }
                                                   }
-                                                  str = arr;
+                                                  else {
+                                                      split = true;
+                                                      // Split and continue.
+                                                      arr = [];
+                                                      subset = [];
+                                                      var start = 0, end = ele.max;
+                                                      for(j = 0; j < val.length/ele.max; j++) {
+                                                          subset = val.slice(start, end);
+                                                          arr.push(_append(str, subset, true));
+                                                          start += ele.max;
+                                                          end += ele.max;
+                                                      }
+                                                      str = arr;
+                                                  }
                                               }
+                                          }
+                                          else {
+                                              str = _append(str, val, true);
                                           }
                                       }
                                       else {
-                                          str = _append(str, val, true);
+                                          // Split if not already split. If already split, error
+                                          if(split) {
+                                              throw {
+                                                  error: 'Template can not have multiple single-valued params with multiple values'
+                                              }
+                                          }
+                                          else {
+                                              split = true;
+                                              // Split and continue.
+                                              arr = [];
+                                              for(j = 0; j < val.length; j++) {
+                                                  arr.push(_append(str, val[j], true));
+                                              }
+                                              str = arr;
+                                          }
                                       }
                                   }
                                   else {
-                                      // Split if not already split. If already split, error
-                                      if(split) {
-                                          throw {
-                                              error: 'Template can not have multiple single-valued params with multiple values'
-                                          }
-                                      }
-                                      else {
-                                          split = true;
-                                          // Split and continue.
-                                          arr = [];
-                                          for(j = 0; j < val.length; j++) {
-                                              arr.push(_append(str, val[j], true));
-                                          }
-                                          str = arr;
-                                      }
+                                      str = _append(str, val, true);
                                   }
                               }
-                              else {
-                                  str = _append(str, val, true);
-                              }
-                          }
-                          else if(o[i].required) {
-                              throw {
-                                  error: 'Token ' + o[i].variable + ' not specified. Processed ' + str
+                              else if(ele.required) {
+                                  throw {
+                                      error: 'Token ' + ele.variable + ' not specified. Processed ' + str
+                                  }
                               }
                           }
                       }
@@ -273,13 +300,23 @@ module.exports = (function(){
 
 
         if (input.substr(pos).match(/^[^^ "'<>`{|}]/) !== null) {
-          var result0 = input.charAt(pos);
+          var result2 = input.charAt(pos);
           pos++;
         } else {
-          var result0 = null;
+          var result2 = null;
           if (reportMatchFailures) {
             matchFailed("[^^ \"'<>`{|}]");
           }
+        }
+        if (result2 !== null) {
+          var result0 = result2;
+        } else {
+          var result1 = parse_expression();
+          if (result1 !== null) {
+            var result0 = result1;
+          } else {
+            var result0 = null;;
+          };
         }
 
 
@@ -577,9 +614,19 @@ module.exports = (function(){
         }
         var result2 = result1 !== null
           ? (function(l) {
-              var r = '';
-              for(i = 0; i < l.length; i++) { r += l[i]; }
-              return r;
+              var o = [];
+              o.push(l[0]);
+              var current = 0;
+              for(var i = 1; i < l.length; i++) {
+                  if(typeof l[i] === 'string' && typeof o[current] === 'string') {
+                      o[current] = o[current] + l[i];
+                  }
+                  else {
+                      o.push(l[i]);
+                      current++;
+                  }
+              }
+              return (o.length === 1) ? o[0] : o;
           })(result1)
           : null;
         if (result2 !== null) {

--- a/modules/uri-template/peg/uri-template.peg
+++ b/modules/uri-template/peg/uri-template.peg
@@ -28,6 +28,22 @@ URITemplate  = c:( literal / expression )* {
             current++;
         }
     }
+    function select(path, obj) {
+        var splits = !path ? [] : path.split('.');
+        var curr = obj;
+        for(var i = 0; i < splits.length; i++) {
+            if(curr[splits[i]]) {
+                curr = curr[splits[i]];
+                if(i < splits.length - 1 && curr.constructor === Array && curr.length > 0) {
+                    curr = curr[0];
+                }
+            }
+            else {
+                return null;
+            }
+        }
+        return curr;
+    }
     function _append(str, val, encode) {
         var j;
         if(str.constructor === Array) {
@@ -40,80 +56,91 @@ URITemplate  = c:( literal / expression )* {
         }
         return str;
     }
-    function _format(str, values, defaults) {
+    function _format(str, values, defaults, stream) {
         values = values || {};
         defaults = defaults || {};
-        var i, j, val, split = false, arr, subset;
-        for(i = 0; i < o.length; i++) {
-            if(o[i].constructor === String) {
-                str = _append(str, o[i], false);
+        var i, j, val, split = false, arr, subset, key;
+        stream = stream || o;
+        var ele;
+        for(i = 0; i < stream.length; i++) {
+            ele = stream[i];
+            if(ele.constructor === String) {
+                str = _append(str, ele, false);
             }
             else {
-                val = values[o[i].variable] || defaults[o[i].variable];
-                if(val) {
-                    if(val.constructor == Array) {
-                        // But is the token multivalued?
-                        if(val.length === 1) {
-                            str = _append(str, val, true);
-                        }
-                        else if(o[i].multivalued) {
-                            if(o[i].max) {
-                                if(val.length <= o[i].max) {
-                                    // Append as usual
-                                    str = _append(str, val, true);
-                                }
-                                else {
-                                    // Split the values into multiple and append each
-                                    if(split) {
-                                        throw {
-                                            error: 'Template can not have multiple single-valued params with multiple values'
-                                        }
+                if(ele.variable.constructor == Array) {
+                    // Case of nested token - only single valued for now
+                    key = _format('', values, defaults, ele.variable);
+                    val = select(key, values) || select(key, defaults);
+                    str = str + val;
+                }
+                else {
+                    val = select(ele.variable, values) || select(ele.variable, defaults);
+                    if(val) {
+                        if(val.constructor == Array) {
+                            // But is the token multivalued?
+                            if(val.length === 1) {
+                                str = _append(str, val, true);
+                            }
+                            else if(ele.multivalued) {
+                                if(ele.max) {
+                                    if(val.length <= ele.max) {
+                                        // Append as usual
+                                        str = _append(str, val, true);
                                     }
                                     else {
-                                        split = true;
-                                        // Split and continue.
-                                        arr = [];
-                                        subset = [];
-                                        var start = 0, end = o[i].max;
-                                        for(j = 0; j < val.length/o[i].max; j++) {
-                                            subset = val.slice(start, end);
-                                            arr.push(_append(str, subset, true));
-                                            start += o[i].max;
-                                            end += o[i].max;
+                                        // Split the values into multiple and append each
+                                        if(split) {
+                                            throw {
+                                                error: 'Template can not have multiple single-valued params with multiple values'
+                                            }
                                         }
-                                        str = arr;
+                                        else {
+                                            split = true;
+                                            // Split and continue.
+                                            arr = [];
+                                            subset = [];
+                                            var start = 0, end = ele.max;
+                                            for(j = 0; j < val.length/ele.max; j++) {
+                                                subset = val.slice(start, end);
+                                                arr.push(_append(str, subset, true));
+                                                start += ele.max;
+                                                end += ele.max;
+                                            }
+                                            str = arr;
+                                        }
                                     }
+                                }
+                                else {
+                                    str = _append(str, val, true);
                                 }
                             }
                             else {
-                                str = _append(str, val, true);
+                                // Split if not already split. If already split, error
+                                if(split) {
+                                    throw {
+                                        error: 'Template can not have multiple single-valued params with multiple values'
+                                    }
+                                }
+                                else {
+                                    split = true;
+                                    // Split and continue.
+                                    arr = [];
+                                    for(j = 0; j < val.length; j++) {
+                                        arr.push(_append(str, val[j], true));
+                                    }
+                                    str = arr;
+                                }
                             }
                         }
                         else {
-                            // Split if not already split. If already split, error
-                            if(split) {
-                                throw {
-                                    error: 'Template can not have multiple single-valued params with multiple values'
-                                }
-                            }
-                            else {
-                                split = true;
-                                // Split and continue.
-                                arr = [];
-                                for(j = 0; j < val.length; j++) {
-                                    arr.push(_append(str, val[j], true));
-                                }
-                                str = arr;
-                            }
+                            str = _append(str, val, true);
                         }
                     }
-                    else {
-                        str = _append(str, val, true);
-                    }
-                }
-                else if(o[i].required) {
-                    throw {
-                        error: 'Token ' + o[i].variable + ' not specified. Processed ' + str
+                    else if(ele.required) {
+                        throw {
+                            error: 'Token ' + ele.variable + ' not specified. Processed ' + str
+                        }
                     }
                 }
             }
@@ -140,7 +167,7 @@ URITemplate  = c:( literal / expression )* {
 // any Unicode character except: CTL, SP,
 // DQUOTE, "'", // "<", ">", "\", "`", "{", "|", "}"
 
-literal = [^^ "'<>\`{|}]
+literal = [^^ "'<>\`{|}] / expression
 
 expression =  "{" op:operator* v:variable "}" {
     var token = {
@@ -182,9 +209,19 @@ multivalued = d:digits? '|' {
 }
 
 variable = l:literal* {
-    var r = '';
-    for(i = 0; i < l.length; i++) { r += l[i]; }
-    return r;
+    var o = [];
+    o.push(l[0]);
+    var current = 0;
+    for(var i = 1; i < l.length; i++) {
+        if(typeof l[i] === 'string' && typeof o[current] === 'string') {
+            o[current] = o[current] + l[i];
+        }
+        else {
+            o.push(l[i]);
+            current++;
+        }
+    }
+    return (o.length === 1) ? o[0] : o;
 }
 
 digits = d:[0-9]* {

--- a/modules/uri-template/test/uri-template-test.js
+++ b/modules/uri-template/test/uri-template-test.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-"use strict"
+'use strict'
 
 var uriTemplate = require(__dirname + '/../lib/uri-template'),
     sys = require('sys'),
@@ -46,7 +46,7 @@ module.exports = {
     },
 
     'required': function(test) {
-        var u = "http://www.subbu.org?p1={p1}&p2={^p2}&p3={p3}";
+        var u = 'http://www.subbu.org?p1={p1}&p2={^p2}&p3={p3}';
         var p = uriTemplate.parse(u);
         var e = [
             'http://www.subbu.org?p1=',
@@ -125,7 +125,7 @@ module.exports = {
     },
 
     'multivalued-split': function(test) {
-        var str = "http://www.subbu.org?p1={p1}&p2={p2}";
+        var str = 'http://www.subbu.org?p1={p1}&p2={p2}';
         var template = uriTemplate.parse(str);
         var uri = template.format({
             p1: 'v1',
@@ -139,7 +139,7 @@ module.exports = {
     },
 
     'multivalued-encode': function(test) {
-        var str = "http://www.subbu.org?p1={p1}&p2={|p2}";
+        var str = 'http://www.subbu.org?p1={p1}&p2={|p2}';
         var template = uriTemplate.parse(str);
         var uri = template.format({
             p1: 'v1',
@@ -150,7 +150,7 @@ module.exports = {
     },
 
     'multivalued-multi-multi': function(test) {
-        var str = "http://www.subbu.org?p1={p1}&p2={p2}&p3={p3}";
+        var str = 'http://www.subbu.org?p1={p1}&p2={p2}&p3={p3}';
         var template = uriTemplate.parse(str);
         try {
             template.format({
@@ -168,7 +168,7 @@ module.exports = {
     },
 
     'multivalued-required': function(test) {
-        var str = "http://www.subbu.org?p1={p1}&p2={^|p2}&p3={^|p3}";
+        var str = 'http://www.subbu.org?p1={p1}&p2={^|p2}&p3={^|p3}';
         var p = uriTemplate.parse(str);
         var e = [
             'http://www.subbu.org?p1=',
@@ -193,7 +193,7 @@ module.exports = {
     },
 
     'multivalued-required-max': function(test) {
-        var str = "http://www.subbu.org?p1={p1}&p2={^|p2}&p3={^|p3}&p4={^20|p4}";
+        var str = 'http://www.subbu.org?p1={p1}&p2={^|p2}&p3={^|p3}&p4={^20|p4}';
         var p = uriTemplate.parse(str);
         var e = [
             'http://www.subbu.org?p1=',
@@ -225,7 +225,7 @@ module.exports = {
     },
 
     'multivalued-split-max': function(test) {
-        var str = "http://www.subbu.org?p1={p1}&p2={p2}&p3={2|p3}";
+        var str = 'http://www.subbu.org?p1={p1}&p2={p2}&p3={2|p3}';
         var template = uriTemplate.parse(str);
         var uri = template.format({
             p1: 'v1',
@@ -240,7 +240,7 @@ module.exports = {
     },
 
     'multivalued-split-max-more': function(test) {
-        var str = "http://www.subbu.org?p1={p1}&p2={p2}&p3={2|p3}";
+        var str = 'http://www.subbu.org?p1={p1}&p2={p2}&p3={2|p3}';
         var template = uriTemplate.parse(str);
         var uri = template.format({
             p1: 'v1',
@@ -256,7 +256,7 @@ module.exports = {
     },
 
     'multivalued-split-max-less': function(test) {
-        var str = "http://www.subbu.org?p1={p1}&p2={p2}&p3={5|p3}";
+        var str = 'http://www.subbu.org?p1={p1}&p2={p2}&p3={5|p3}';
         var template = uriTemplate.parse(str);
         var uri = template.format({
             p1: 'v1',
@@ -268,7 +268,7 @@ module.exports = {
     },
 
     'encode': function(test) {
-        var str = "http://www.foo.com?p1={p1}&p2={p2}&p3={5|p3}";
+        var str = 'http://www.foo.com?p1={p1}&p2={p2}&p3={5|p3}';
         var template = uriTemplate.parse(str);
         var uri = template.format({
             p1: 'this is a value',
@@ -280,12 +280,54 @@ module.exports = {
     },
 
     'merge': function(test) {
-        var str = "http://www.foo.com?p1={p1}&p2={p2}&p3={#p3}";
+        var str = 'http://www.foo.com?p1={p1}&p2={p2}&p3={#p3}';
         var template = uriTemplate.parse(str);
         test.equals(template.merge(), 'block');
-        str = "http://www.foo.com?p1={p1}&p2={p2}&p3={p3}";
+        str = 'http://www.foo.com?p1={p1}&p2={p2}&p3={p3}';
         template = uriTemplate.parse(str);
         test.ok(template.merge(), 'field');
+        test.done();
+    },
+
+    'format-nested': function(test) {
+        var u = 'http://www.subbu.org?p1={a.p1}&p2={^a.p2}&p3={a.p3}';
+        var p = uriTemplate.parse(u);
+        var s = p.format({
+            a : {
+                p1: 'v1',
+                p2: 'v2',
+                p3: 'v3'
+            }
+        });
+        test.equal(s, 'http://www.subbu.org?p1=v1&p2=v2&p3=v3');
+        test.done();
+    },
+
+
+    'format-no-values': function(test) {
+        var u = 'http://www.subbu.org?p1={a.p1}&p2={a.p2}&p3={a.p3}';
+        var p = uriTemplate.parse(u);
+        var s = p.format({});
+        test.equal(s, 'http://www.subbu.org?p1=&p2=&p3=');
+        test.done();
+    },
+
+    'nested-tokens': function(test) {
+        var u = 'http://www.foo.com?p1={p1}&p2={config.{ua}.apikey}';
+        var p = uriTemplate.parse(u);
+        var util = require('util');
+
+        var s = p.format({
+            p1: 'v1',
+            ua: 'safari',
+            config: {
+                safari: {
+                    apikey: '1234'
+                }
+            }
+        }, true);
+
+        test.equal(s, 'http://www.foo.com?p1=v1&p2=1234');
         test.done();
     }
 };


### PR DESCRIPTION
This change will support templates like

```
http://www.foo.com?p1={p1}&p2={config.{ua}.apikey}
```

This can be processed using data

```
{
    p1: 'v1',
    ua: 'safari',
    config: {
        safari: {
            apikey: '1234'
        }
    }
}
```

The primary use case for this feature is to allow client specific API keys.
