### PR TITLE
Delete undefineds while wiring up the __proto__ chain

### DIFF
--- a/modules/engine/lib/engine/http.request.js
+++ b/modules/engine/lib/engine/http.request.js
@@ -461,6 +461,11 @@ function prepareParams() {
             params.__proto__ = ref;
         }
         else {
+            // Delete undefined properties as an undefined will override a defined in the __proto__
+            // chain
+            _.each(arg, function(v, p) {
+                if(v === undefined) delete arg[p];
+            });
             ref.__proto__ = arg;
             ref = arg;
         }

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.3.13",
+    "version": "0.3.14",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/test/exec-param-overrides-test.js
+++ b/modules/engine/test/exec-param-overrides-test.js
@@ -33,7 +33,7 @@ var engine = new Engine({
 
 module.exports = {
     // Test staging config, but pass a request param to override
-    'testRequestParam': function(test) {
+    'test-req-param': function(test) {
         // Start a file server
         var server = http.createServer(function(req, res) {
             var parsed = require('url').parse(req.url)
@@ -70,7 +70,7 @@ module.exports = {
         });
     },
 
-    'testRequestParamOverride': function(test) {
+    'test-req-param-override': function(test) {
         // Start a file server
         var server = http.createServer(function(req, res) {
             var parsed = require('url').parse(req.url)
@@ -115,7 +115,51 @@ module.exports = {
         });
     },
 
-    'testHeaderOverride': function(test) {
+    'test-req-param-override-undefined': function(test) {
+        // Start a file server
+        var server = http.createServer(function(req, res) {
+            var parsed = require('url').parse(req.url)
+            var body = {
+                query: parsed.query
+            }
+            res.writeHead(200, {
+                'Content-Type' : 'text/plain'
+            });
+            res.end(JSON.stringify(body));
+        });
+        server.listen(3000, function() {
+            // Do the test here.
+            var engine = new Engine({
+                connection : 'close'
+            });
+            var script = 'create table myapi \
+                            on select get from "http://localhost:3000/myapi?param={value}";\
+                      return select * from myapi where value = "{val}"';
+            engine.exec({
+                script: script,
+                request: {
+                    params: {
+                        value: 'myParamOverride'
+                    }
+                },
+                cb: function(err, results) {
+                    if(err) {
+                        console.log(err.stack || err);
+                        test.ok(false, 'Grrr');
+                        test.done();
+                    }
+                    else {
+                        results = results.body;
+                        test.equals(results.query, 'param=myParamOverride');
+                        test.done();
+                    }
+                    server.close();
+                }
+            });
+        });
+    },
+
+    'test-header-override': function(test) {
         // Start a file server
         var server = http.createServer(function(req, res) {
             var parsed = require('url').parse(req.url)
@@ -135,6 +179,51 @@ module.exports = {
             var script = 'create table myapi \
                             on select get from "http://localhost:3000/myapi?param={value}";\
                           return select * from myapi';
+            engine.exec({
+                script: script,
+                request: {
+                    headers: {
+                        value: 'myHeaderOverride'
+                    }
+                },
+                cb: function(err, results) {
+                    if(err) {
+                        console.log(err.stack || err);
+                        test.ok(false, 'Grrr');
+                        test.done();
+                    }
+                    else {
+                        results = results.body;
+                        test.equals(results.query, 'param=myHeaderOverride');
+                        test.done();
+                    }
+                    server.close();
+
+                }
+            });
+        });
+    },
+
+    'test-header-override-undefined': function(test) {
+        // Start a file server
+        var server = http.createServer(function(req, res) {
+            var parsed = require('url').parse(req.url)
+            var body = {
+                query: parsed.query
+            }
+            res.writeHead(200, {
+                'Content-Type' : 'text/plain'
+            });
+            res.end(JSON.stringify(body));
+        });
+        server.listen(3000, function() {
+            // Do the test here.
+            var engine = new Engine({
+                connection : 'close'
+            });
+            var script = 'create table myapi \
+                            on select get from "http://localhost:3000/myapi?param={value}";\
+                          return select * from myapi where value = "{val}"';
             engine.exec({
                 script: script,
                 request: {


### PR DESCRIPTION
Consider a statement

```
select * from blah where foo = "{foo}"
```

Here the value of foo will be "undefined" since it is not defined in the script. It may come from other sources at runtime. The previous change I did to prepareParams in http.request.js causes the undefined to be picked up. This is a regression.
