### PR TITLE
Fix in-proc joins

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Jan 31, 2011
+
+* Improve support for in-proc selection and joins. If the RHS is multi-valued, selection is ORed.
+  Multiple conditions are ANDed ('and' === and).
+
 ## Jan 25, 2011
 
 * Support for extended xml content-types returned  per rfc: http://www.ietf.org/rfc/rfc3023.txt

--- a/modules/engine/lib/engine/select.js
+++ b/modules/engine/lib/engine/select.js
@@ -252,10 +252,8 @@ function execInternal(opts, statement, cb, parentEvent) {
                     var filtered = resource;
                     if(statement.whereCriteria && statement.whereCriteria.length > 0) {
                         filtered = _.isArray(resource) ? resource : [resource];
-                        // For each row in the data set, use a mapper to check if the row
-                        // should be selected. The mapper does this by applying each where condition.
-                        // If they all eval to true, select the row. The filter then selects the
-                        // selectable rows.
+                        // All and conditions should match. If the RHS of a condition
+                        // has multiple values, they are ORed.
                         //
                         for(i = 0; i < statement.whereCriteria.length; i++) {
                             var cond = statement.whereCriteria[i];

--- a/modules/engine/lib/engine/select.js
+++ b/modules/engine/lib/engine/select.js
@@ -146,7 +146,7 @@ function execInternal(opts, statement, cb, parentEvent) {
             }(cond, name));
         }
         //
-        // This is an IN condition. RHS could be a comma separated string or a SELECT
+        // This is an IN condition. RHS could be a comma separated values or a SELECT
         else if(cond.operator === 'in') {
             name = cond.lhs.name;
             if(cond.rhs.fromClause) {
@@ -200,6 +200,7 @@ function execInternal(opts, statement, cb, parentEvent) {
     // have the values to execute this statement
     async.parallel(tasks,
         function(err, results) {
+            var i, j;
             // Now fetch each resource from left to right
             _.each(statement.fromClause, function(from) {
                 // Reorder results - async results is an array of objects, but we just want an object
@@ -230,27 +231,51 @@ function execInternal(opts, statement, cb, parentEvent) {
                     resource = jsonfill.unwrap(resource);
 
                     // Local filtering (rudimentary)
-                    var filtered;
-                    if(statement.whereCriteria && statement.whereCriteria.length > 0) {
-                        filtered = [];
-                        // Wrap into an array if source is not an array. Otherwise we will end up
-                        // iterating over its props.
-                        resource = _.isArray(resource) ? resource : [resource];
-
-                        _.each(resource, function(row) {
-                            _.each(statement.whereCriteria, function(cond) {
-                                assert.ok(cond.operator === '=', 'Local filtering supported for = only');
-                                var path = cond.lhs.name;
-                                if(path.indexOf(from.alias + '.') === 0) {
-                                    path = path.substr(from.alias.length + 1);
-                                }
-                                var expected = cond.rhs.value;
-                                var result = jsonPath.eval(row, path, {flatten: true});
-                                if(result && _.isArray(result) && result.length == 1 && result[0] === expected) {
-                                    filtered.push(row);
-                                }
+                    // Prep expected once
+                    var expecteds = _.map(statement.whereCriteria, function(cond) {
+                        var expected = [];
+                        if(cond.operator === 'in') {
+                            _.each(cond.rhs.value, function (val) {
+                                expected = expected.concat(jsonfill.fill(val, context));
                             });
-                        });
+                        }
+                        else if(cond.operator === '=') {
+                            expected = expected.concat(jsonfill.fill(cond.rhs.value, context));
+                        }
+                        else {
+                            assert.ok(cond.operator === '=', 'Local filtering supported for = only');
+                        }
+                        return expected;
+                    });
+                    // Wrap into an array if source is not an array. Otherwise we will end up
+                    // iterating over its props.
+                    var filtered = resource;
+                    if(statement.whereCriteria && statement.whereCriteria.length > 0) {
+                        filtered = _.isArray(resource) ? resource : [resource];
+                        // For each row in the data set, use a mapper to check if the row
+                        // should be selected. The mapper does this by applying each where condition.
+                        // If they all eval to true, select the row. The filter then selects the
+                        // selectable rows.
+                        //
+                        for(i = 0; i < statement.whereCriteria.length; i++) {
+                            var cond = statement.whereCriteria[i];
+                            var expected = expecteds[i];
+                            var path = cond.lhs.name;
+                            if(path.indexOf(from.alias + '.') === 0) {
+                                path = path.substr(from.alias.length + 1);
+                            }
+                            filtered = _.filter(filtered, function(row) {
+                                var matched = false;
+                                var result = jsonPath.eval(row, path, {flatten: true});
+                                // If the result matches any expected[], keep it.
+                                for(j = 0; j < expected.length; j++) {
+                                    if(!matched && result && _.isArray(result) && result.length == 1 && result[0] === expected[j]) {
+                                        matched = true;
+                                    }
+                                }
+                                return matched;
+                            });
+                        }
                     }
                     else {
                         // If there are no where conditions, use the original
@@ -262,7 +287,6 @@ function execInternal(opts, statement, cb, parentEvent) {
                         if(statement.assign) {
                             context[statement.assign] = projected;
                             emitter.emit(statement.assign, projected);
-                            console.log('>> emitting ' + statement.assign + ' ' + projected);
                         }
                         return apiTx.cb(null, {
                             headers: {

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.4.0-beta.1",
+    "version": "0.4.0-beta.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/test/exec-select-join-test.js
+++ b/modules/engine/test/exec-select-join-test.js
@@ -211,5 +211,86 @@ module.exports = {
                 }
             });
         })
+    },
+
+    'select-join-in' : function(test) {
+        var script = 'a = ["1", "2"];\
+                      b = [{"id": "1", "name": "abc"}];\
+                      return select * from b where id in ("{a}");';
+        engine.execute(script, function(emitter) {
+            emitter.on('end', function(err, list) {
+                if(err) {
+                    test.fail('got error: ' + err.stack || err);
+                    test.done();
+                }
+                else {
+                    test.equals(list.headers['content-type'], 'application/json', 'JSON expected');
+                    test.deepEqual(list.body, [{id: 1, name: 'abc'}]);
+                    test.done();
+                }
+            });
+        })
+    },
+
+    'select-join-in-2' : function(test) {
+        var script = 'a = ["1", "2"];\
+                          b = [{"id": "1", "name": "abc"}, {"id": "2", "name": "def"}];\
+                          return select * from b where id in ("{a}");';
+        engine.execute(script, function (emitter) {
+            emitter.on('end', function (err, list) {
+                if(err) {
+                    test.fail('got error: ' + err.stack || err);
+                    test.done();
+                }
+                else {
+                    test.equals(list.headers['content-type'], 'application/json', 'JSON expected');
+                    test.deepEqual(list.body, [
+                        {id: 1, name: 'abc'},
+                        {id: 2, name: 'def'}
+                    ]);
+                    test.done();
+                }
+            });
+        })
+    },
+
+    'select-join-in-and' : function(test) {
+        var script = 'a = ["1", "2"];\
+                              b = [{"id": "1", "name": "abc"}, {"id": "2", "name": "def"}];\
+                              return select * from b where id in ("{a}") and name = "def";';
+        engine.execute(script, function (emitter) {
+            emitter.on('end', function (err, list) {
+                if(err) {
+                    test.fail('got error: ' + err.stack || err);
+                    test.done();
+                }
+                else {
+                    test.equals(list.headers['content-type'], 'application/json', 'JSON expected');
+                    test.deepEqual(list.body, [
+                        {id: 2, name: 'def'}
+                    ]);
+                    test.done();
+                }
+            });
+        })
+    },
+
+    'select-join-in-and-2' : function(test) {
+        var script = 'a = ["1", "3"];\
+                              b = [{"id": "1", "name": "abc"}, {"id": "2", "name": "def"}, {"id": "3", "name": "ghi"}];\
+                              return select * from b where id in ("{a}") and name = "def";';
+        engine.execute(script, function (emitter) {
+            emitter.on('end', function (err, list) {
+                if(err) {
+                    test.fail('got error: ' + err.stack || err);
+                    test.done();
+                }
+                else {
+                    test.equals(list.headers['content-type'], 'application/json', 'JSON expected');
+                    test.deepEqual(list.body, []);
+                    test.done();
+                }
+            });
+        })
     }
 }


### PR DESCRIPTION
Scripts like the following fail before this fix.

```
a = ["1", "2"];
b = [{"id": "1", "name": "abc"}];
return select * from b where id in ("{a}");
```
