### PR TITLE
Remove connection: close

### DIFF
--- a/modules/engine/test/dynamic-body-patch-test.js
+++ b/modules/engine/test/dynamic-body-patch-test.js
@@ -22,8 +22,7 @@ var _ = require('underscore'),
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    'connection': 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {

--- a/modules/engine/test/empty-json-handle-test.js
+++ b/modules/engine/test/empty-json-handle-test.js
@@ -33,7 +33,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/empty-json-resp.ql', 'UTF-8');
 
@@ -65,7 +64,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/empty-json-resp.ql', 'UTF-8');
 
@@ -96,7 +94,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/empty-json-resp.ql', 'UTF-8');
 
@@ -128,7 +125,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/empty-json-resp.ql', 'UTF-8');
 

--- a/modules/engine/test/empty-where-val-test.js
+++ b/modules/engine/test/empty-where-val-test.js
@@ -41,7 +41,6 @@ module.exports = {
         });
         server.listen(3000, function() {
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/empty-where-val.ql', 'UTF-8');
             engine.exec(script, function(err, result) {

--- a/modules/engine/test/engine-emitter-new-test.js
+++ b/modules/engine/test/engine-emitter-new-test.js
@@ -24,8 +24,7 @@ module.exports = {
     'compile-err': function(test) {
         var engine = new Engine({
             tables : __dirname + '/tables',
-            config: __dirname + '/config/dev.json',
-            connection: 'close'
+            config: __dirname + '/config/dev.json'
         });
         var script;
         script = 'desca table foo';
@@ -75,8 +74,7 @@ module.exports = {
     'desc': function(test) {
         var engine = new Engine({
             tables : __dirname + '/tables',
-            config: __dirname + '/config/dev.json',
-            connection: 'close'
+            config: __dirname + '/config/dev.json'
         });
         var script;
         script = 'desc foo';
@@ -102,8 +100,7 @@ module.exports = {
     'select-error': function(test) {
         var engine = new Engine({
             tables : __dirname + '/tables',
-            config: __dirname + '/config/dev.json',
-            connection: 'close'
+            config: __dirname + '/config/dev.json'
         });
         var script;
         script = 'select * from ebay.finding.items';
@@ -129,8 +126,7 @@ module.exports = {
     'select-ok': function(test) {
         var engine = new Engine({
             tables : __dirname + '/tables',
-            config: __dirname + '/config/dev.json',
-            'connection': 'close'
+            config: __dirname + '/config/dev.json'
         });
         var script;
         script = 'select * from ebay.finding.items where keywords = "ipad"';
@@ -164,8 +160,7 @@ module.exports = {
     'define': function(test) {
         var engine = new Engine({
             tables : __dirname + '/tables',
-            config: __dirname + '/config/dev.json',
-            'connection': 'close'
+            config: __dirname + '/config/dev.json'
         });
         var script = 'data = {\
                 "name" : {\

--- a/modules/engine/test/engine-emitter-test.js
+++ b/modules/engine/test/engine-emitter-test.js
@@ -25,8 +25,7 @@ module.exports = {
     'compile-err': function(test) {
         var engine = new Engine({
             tables : __dirname + '/tables',
-            config: __dirname + '/config/dev.json',
-            connection: 'close'
+            config: __dirname + '/config/dev.json'
         });
         var script;
         script = 'desca table foo';
@@ -96,8 +95,7 @@ module.exports = {
     'desc': function(test) {
         var engine = new Engine({
             tables : __dirname + '/tables',
-            config: __dirname + '/config/dev.json',
-            connection: 'close'
+            config: __dirname + '/config/dev.json'
         });
         var script;
         script = 'desc foo';
@@ -133,8 +131,7 @@ module.exports = {
     'select-error': function(test) {
         var engine = new Engine({
             tables : __dirname + '/tables',
-            config: __dirname + '/config/dev.json',
-            connection: 'close'
+            config: __dirname + '/config/dev.json'
         });
         var script;
         script = 'select * from ebay.finding.items';
@@ -170,8 +167,7 @@ module.exports = {
     'select-ok': function(test) {
         var engine = new Engine({
             tables : __dirname + '/tables',
-            config: __dirname + '/config/dev.json',
-            'connection': 'close'
+            config: __dirname + '/config/dev.json'
         });
         var script;
         script = 'select * from ebay.finding.items where keywords = "ipad"';
@@ -214,8 +210,7 @@ module.exports = {
     'define': function(test) {
         var engine = new Engine({
             tables : __dirname + '/tables',
-            config: __dirname + '/config/dev.json',
-            'connection': 'close'
+            config: __dirname + '/config/dev.json'
         });
         var script = 'data = {\
                 "name" : {\

--- a/modules/engine/test/error-events-for-logutil-test.js
+++ b/modules/engine/test/error-events-for-logutil-test.js
@@ -20,11 +20,6 @@ var _ = require('underscore'),
     fs = require('fs'),
     util = require('util');
 
-var engine = new Engine({
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
-});
-
 module.exports = {
     'error event for error code': function(test) {
 
@@ -48,7 +43,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             engine.once(Engine.Events.ERROR, errorHandler);
 
@@ -83,7 +77,6 @@ module.exports = {
 
         // Do the test here.
         var engine = new Engine({
-            connection : 'close'
         });
         engine.once(Engine.Events.ERROR, errorHandler);
         var script = fs.readFileSync(__dirname + '/mock/empty-json-resp.ql', 'UTF-8');
@@ -113,7 +106,6 @@ module.exports = {
 
         // Do the test here.
         var engine = new Engine({
-            connection : 'close'
         });
         engine.once(Engine.Events.ERROR, errorHandler);
         var script = fs.readFileSync(__dirname + '/mock/forIncMkyPatchErr.ql', 'UTF-8');

--- a/modules/engine/test/exec-assign-events.js
+++ b/modules/engine/test/exec-assign-events.js
@@ -24,7 +24,6 @@ var _ = require('underscore'),
 module.exports = {
     'assign events': function (test) {
         var engine = new Engine({
-            connection : 'close'
         });
         var script = fs.readFileSync(__dirname + '/mock/assign-events.ql', 'UTF-8');
         engine.execute(script, function(emitter) {

--- a/modules/engine/test/exec-config-lookup-test.js
+++ b/modules/engine/test/exec-config-lookup-test.js
@@ -23,8 +23,7 @@ var Engine = require('../lib/engine'),
 
 var engine = new Engine({
     tables: __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {

--- a/modules/engine/test/exec-create-test.js
+++ b/modules/engine/test/exec-create-test.js
@@ -21,8 +21,7 @@ var _ = require('underscore'),
     util = require('util');
 
 var engine = new Engine({
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
      exports['temp-table'] = function(test) {
@@ -44,7 +43,6 @@ var engine = new Engine({
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/create.ql', 'UTF-8');
    

--- a/modules/engine/test/exec-describe-routes-test.js
+++ b/modules/engine/test/exec-describe-routes-test.js
@@ -26,8 +26,7 @@ exports["describe route '/foo/bar/{selector}?userid={userId}&itemid={itemId}' us
     var engine = new Engine({
             tables : __dirname + '/mock-routes/tables',
             routes : __dirname + '/mock-routes/routes',
-            config : __dirname + '/config/dev.json',
-            connection : 'close'
+            config : __dirname + '/config/dev.json'
         });
     var q = "describe route '/foo/bar/{selector}?userid={userId}&itemid={itemId}' using method get";
         engine.exec(q, function(err, list) {
@@ -55,8 +54,7 @@ exports["describe route '/ping/pong' using method put"] = function (test) {
     var engine = new Engine({
             tables : __dirname + '/mock-routes/tables',
             routes : __dirname + '/mock-routes/routes',
-            config : __dirname + '/config/dev.json',
-            connection : 'close'
+            config : __dirname + '/config/dev.json'
         });
     var q = "describe route '/ping/pong' using method put";
         engine.exec(q, function(err, list) {

--- a/modules/engine/test/exec-describe-test.js
+++ b/modules/engine/test/exec-describe-test.js
@@ -25,8 +25,7 @@ logger.add(logger.transports.Console, {level: 'error'});
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 exports['describe'] = function (test) {

--- a/modules/engine/test/exec-find-all-test.js
+++ b/modules/engine/test/exec-find-all-test.js
@@ -42,7 +42,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/find-all.ql', 'UTF-8');
             engine.exec(script, function(err, results) {
@@ -102,7 +101,6 @@ module.exports = {
             server.listen(3000, function() {
                 // Do the test here.
                 var engine = new Engine({
-                    connection : 'close'
                 });
                 var script = fs.readFileSync(__dirname + '/mock/find-all-flatten.ql', 'UTF-8');
                 engine.exec(script, function(err, results) {

--- a/modules/engine/test/exec-insert-obj.js
+++ b/modules/engine/test/exec-insert-obj.js
@@ -24,7 +24,6 @@ var _ = require('underscore'),
 module.exports = {
     'assign events': function (test) {
         var engine = new Engine({
-            connection: 'close'
         });
         var script = fs.readFileSync(__dirname + '/mock/insert-obj.ql', 'UTF-8');
         engine.execute(script, function (emitter) {

--- a/modules/engine/test/exec-param-overrides-test.js
+++ b/modules/engine/test/exec-param-overrides-test.js
@@ -26,8 +26,7 @@ logger.add(logger.transports.Console, {level: 'error'});
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection : 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {
@@ -47,7 +46,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = 'create table myapi \
                             on select get from "http://localhost:3000/myapi?param={value}";\
@@ -84,7 +82,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = 'create table myapi \
                             on select get from "http://localhost:3000/myapi?param={value}";\
@@ -129,7 +126,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = 'create table myapi \
                             on select get from "http://localhost:3000/myapi?param={value}";\
@@ -173,7 +169,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = 'create table myapi \
                             on select get from "http://localhost:3000/myapi?param={value}";\
@@ -218,7 +213,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = 'create table myapi \
                             on select get from "http://localhost:3000/myapi?param={value}";\

--- a/modules/engine/test/exec-scatter-partial-failure.js
+++ b/modules/engine/test/exec-scatter-partial-failure.js
@@ -19,16 +19,7 @@
 var _ = require('underscore'),
     Engine = require('../lib/engine'),
     fs = require('fs'),
-    http = require('http'),
-    util = require('util'),
-    EventEmitter = require('events').EventEmitter(),
-    logger = require('winston');
-
-var engine = new Engine({
-    tables: __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    'connection': 'close'
-});
+    http = require('http');
 
 module.exports = {
     'partial failure': function (test) {
@@ -49,7 +40,6 @@ module.exports = {
         server.listen(3000, function () {
             // Do the test here.
             var engine = new Engine({
-                connection: 'close'
             });
             var q = fs.readFileSync(__dirname + '/mock/scatter-partial-failure.ql', 'UTF-8');
             engine.exec(q, function (err, list) {

--- a/modules/engine/test/exec-scatter-test.js
+++ b/modules/engine/test/exec-scatter-test.js
@@ -21,17 +21,10 @@ var _ = require('underscore'),
     fs = require('fs'),
     http = require('http'),
     util = require('util'),
-    EventEmitter = require('events').EventEmitter(),
     logger = require('winston');
     logger.remove(logger.transports.Console);
     logger.add(logger.transports.Console, {level: 'error'});
     
-   var engine = new Engine({
-      tables : __dirname + '/tables',
-      config: __dirname + '/config/dev.json',
-      'connection': 'close'
-    });
-
    module.exports = {
     'select-times': function(test) {
 	 var server = http.createServer(function(req, res) {
@@ -52,7 +45,6 @@ var _ = require('underscore'),
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
 	    var q = fs.readFileSync(__dirname + '/mock/scatter.ql', 'UTF-8');
        	    engine.exec(q, function(err, list) {
@@ -91,7 +83,6 @@ var _ = require('underscore'),
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
 	    var q = fs.readFileSync(__dirname + '/mock/scatter.ql', 'UTF-8');
             engine.exec({

--- a/modules/engine/test/exec-select-for-csv-test.js
+++ b/modules/engine/test/exec-select-for-csv-test.js
@@ -42,7 +42,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/csvSelect.ql', 'UTF-8');
             engine.exec(script, function(err, results) {
@@ -86,7 +85,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/csvSelect.ql', 'UTF-8');
             engine.exec(script, function(err, results) {
@@ -129,7 +127,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/utf8csvSelect.ql', 'UTF-8');
             engine.exec(script, function(err, results) {

--- a/modules/engine/test/exec-select-join-intersect.js
+++ b/modules/engine/test/exec-select-join-intersect.js
@@ -45,7 +45,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/intersect.ql', 'UTF-8');
             engine.exec(script, function(err, results) {

--- a/modules/engine/test/exec-select-join-test.js
+++ b/modules/engine/test/exec-select-join-test.js
@@ -22,8 +22,7 @@ var _ = require('underscore'),
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {

--- a/modules/engine/test/exec-select-multi-req-merge.js
+++ b/modules/engine/test/exec-select-multi-req-merge.js
@@ -23,8 +23,7 @@ var _ = require('underscore'),
 
 var engine = new Engine({
     tables: __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 // This tests merging of multiple HTTP requests
@@ -109,7 +108,6 @@ module.exports = {
         server.listen(3000, function () {
             // Do the test here.
             var engine = new Engine({
-                connection: 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/merge-block.ql', 'UTF-8');
             engine.exec(script, function (err, results) {

--- a/modules/engine/test/exec-select-rhs-eval-unwrap.js
+++ b/modules/engine/test/exec-select-rhs-eval-unwrap.js
@@ -21,8 +21,7 @@ var _ = require('underscore'),
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {

--- a/modules/engine/test/exec-select-rhs-eval.js
+++ b/modules/engine/test/exec-select-rhs-eval.js
@@ -21,8 +21,7 @@ var _ = require('underscore'),
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {

--- a/modules/engine/test/exec-select-test.js
+++ b/modules/engine/test/exec-select-test.js
@@ -28,8 +28,7 @@ logger.add(logger.transports.Console, {level: 'error'});
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {

--- a/modules/engine/test/exec-select-vs-ref-test.js
+++ b/modules/engine/test/exec-select-vs-ref-test.js
@@ -42,7 +42,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/select-vs-ref.ql', 'UTF-8');
             engine.exec(script, function(err, results) {

--- a/modules/engine/test/exec-show-routes-test.js
+++ b/modules/engine/test/exec-show-routes-test.js
@@ -26,8 +26,7 @@ exports['show routes test'] = function (test) {
     var engine = new Engine({
         tables : __dirname + '/mock-routes/tables',
         routes : __dirname + '/mock-routes/routes',
-        config : __dirname + '/config/dev.json',
-        connection : 'close'
+        config : __dirname + '/config/dev.json'
     });
     var q = 'show routes';
     engine.exec(q, function(err, list) {
@@ -48,8 +47,7 @@ exports['show routes test'] = function (test) {
 exports['show routes with no routes test'] = function (test) {
     var engine = new Engine({
         tables : __dirname + '/mock-routes/tables',
-        config : __dirname + '/config/dev.json',
-        connection : 'close'
+        config : __dirname + '/config/dev.json'
     });
     var q = 'show routes';
     engine.exec(q, function(err, list) {

--- a/modules/engine/test/exec-show-test.js
+++ b/modules/engine/test/exec-show-test.js
@@ -23,8 +23,7 @@ logger.add(logger.transports.Console, {level: 'error'});
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config : __dirname + '/config/dev.json',
-    connection : 'close'
+    config : __dirname + '/config/dev.json'
 });
 
 exports['show tables'] = function (test) {

--- a/modules/engine/test/header-replace-test.js
+++ b/modules/engine/test/header-replace-test.js
@@ -21,8 +21,7 @@ var _ = require('underscore'),
     EventEmitter = require('events').EventEmitter;
 
 var engine = new Engine({
-    config: __dirname + '/config/dev.json',
-    'connection': 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {

--- a/modules/engine/test/max-reqresp-size-test.js
+++ b/modules/engine/test/max-reqresp-size-test.js
@@ -25,8 +25,7 @@ logger.add(logger.transports.Console, {level: 'error'});
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {

--- a/modules/engine/test/nested-joins-test.js
+++ b/modules/engine/test/nested-joins-test.js
@@ -44,7 +44,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/nested1.ql', 'UTF-8');
             engine.exec(script, function(err, results) {
@@ -131,7 +130,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/nested2.ql', 'UTF-8');
             engine.exec(script, function(err, results) {

--- a/modules/engine/test/nested-limit-test.js
+++ b/modules/engine/test/nested-limit-test.js
@@ -25,8 +25,7 @@ var _ = require('underscore'),
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 var maxNestedRequests = engine.config.maxNestedRequests || 50, limit = 10;

--- a/modules/engine/test/plusxml-content-type-test.js
+++ b/modules/engine/test/plusxml-content-type-test.js
@@ -20,11 +20,6 @@ var _ = require('underscore'),
     fs = require('fs'),
     util = require('util');
 
-var engine = new Engine({
-    config:__dirname + '/config/dev.json',
-    connection:'close'
-});
-
 exports['soap+xml'] = function (test) {
     var server = http.createServer(function (req, res) {
 
@@ -51,7 +46,6 @@ exports['soap+xml'] = function (test) {
     server.listen(3000, function () {
         // Do the test here.
         var engine = new Engine({
-            connection:'close'
         });
         var script = fs.readFileSync(__dirname + '/mock/plusXml.ql', 'UTF-8');
 
@@ -105,7 +99,6 @@ exports['atom+xml'] = function (test) {
     server.listen(3000, function () {
         // Do the test here.
         var engine = new Engine({
-            connection:'close'
         });
         var script = fs.readFileSync(__dirname + '/mock/plusXml.ql', 'UTF-8');
 
@@ -144,7 +137,6 @@ exports['foo+xml'] = function (test) {
     server.listen(3000, function () {
         // Do the test here.
         var engine = new Engine({
-            connection:'close'
         });
         var script = fs.readFileSync(__dirname + '/mock/plusXml.ql', 'UTF-8');
 
@@ -192,7 +184,6 @@ exports['bad content'] = function (test) {
     server.listen(3000, function () {
         // Do the test here.
         var engine = new Engine({
-            connection:'close'
         });
         var script = fs.readFileSync(__dirname + '/mock/plusXml.ql', 'UTF-8');
 

--- a/modules/engine/test/proxy-test.js
+++ b/modules/engine/test/proxy-test.js
@@ -76,8 +76,7 @@ module.exports = {
         server.listen(3000, function () {
             // Do the test here.
             var engine = new Engine({
-                config:__dirname + '/config/proxy.json',
-                connection:'close'
+                config:__dirname + '/config/proxy.json'
             });
 
             var script = fs.readFileSync(__dirname + '/mock/proxy.ql', 'UTF-8');
@@ -154,8 +153,7 @@ module.exports = {
         server.listen(3000, "127.0.0.1", function () {
             // Do the test here.
             var engine = new Engine({
-                config:__dirname + '/config/proxy.json',
-                connection:'close'
+                config:__dirname + '/config/proxy.json'
             });
 
             var script = fs.readFileSync(__dirname + '/mock/proxy.ql', 'UTF-8');
@@ -186,8 +184,7 @@ module.exports = {
 
         var engine = new Engine({
             tables:__dirname + '/tables',
-            config:__dirname + '/config/proxy.json',
-            connection:'close'
+            config:__dirname + '/config/proxy.json'
         });
 
         var script = "select * from google.geocode where address = 'Mount Everest'";

--- a/modules/engine/test/request-id-test.js
+++ b/modules/engine/test/request-id-test.js
@@ -24,8 +24,7 @@ var _ = require('underscore'),
     EventEmitter = require('events').EventEmitter;
 
 var engine = new Engine({
-    config: __dirname + '/config/dev.json',
-    'connection': 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {
@@ -48,7 +47,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
 	    var script = fs.readFileSync(__dirname + '/mock/finditems.ql', 'UTF-8');
             var emitter = new EventEmitter();
@@ -97,7 +95,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/finditems-reqid.ql', 'UTF-8');
             var emitter = new EventEmitter();
@@ -146,7 +143,6 @@ module.exports = {
         server.listen(3000, function() {
             // Do the test here.
             var engine = new Engine({
-                connection : 'close'
             });
             var script = fs.readFileSync(__dirname + '/mock/finditems.ql', 'UTF-8');
 
@@ -211,7 +207,6 @@ module.exports = {
  
            var engine = new Engine({
               config: __dirname + '/config/dev.json',
-              'connection': 'close',
               'request-id': 'x-ebay-soa-request-id'
             });
             engine.exec({
@@ -275,7 +270,6 @@ module.exports = {
 
         var engine = new Engine({
             config: __dirname + '/config/dev.json',
-            'connection': 'close',
             'request-id': 'x-ebay-soa-request-id'
         });
         engine.exec({

--- a/modules/engine/test/response-patch-test.js
+++ b/modules/engine/test/response-patch-test.js
@@ -25,8 +25,7 @@ var _ = require('underscore'),
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    'connection': 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {

--- a/modules/engine/test/select-assign-test.js
+++ b/modules/engine/test/select-assign-test.js
@@ -25,8 +25,7 @@ logger.add(logger.transports.Console, {level: 'error'});
 
 var engine = new Engine({
     tables : __dirname + '/tables',
-    config: __dirname + '/config/dev.json',
-    connection: 'close'
+    config: __dirname + '/config/dev.json'
 });
 
 module.exports = {

--- a/modules/engine/test/select-obj-test.js
+++ b/modules/engine/test/select-obj-test.js
@@ -30,7 +30,7 @@ module.exports = {
             }
         };
         q = 'select * from foo';
-        engine.exec({script: q, context: context, connection: 'close', cb: function(err, result) {
+        engine.exec({script: q, context: context, cb: function(err, result) {
             if(err) {
                 test.fail('got error: ' + err.stack);
                 test.done();
@@ -52,7 +52,7 @@ module.exports = {
             }
         };
         q = 'select fname, lname, place from foo';
-        engine.exec({script: q, context: context, connection: 'close', cb: function(err, result) {
+        engine.exec({script: q, context: context, cb: function(err, result) {
             if(err) {
                 test.fail('got error: ' + err.stack);
                 test.done();
@@ -87,7 +87,7 @@ module.exports = {
             }
         };
         q = 'select addresses[0].street, addresses[1].city, name.last from foo';
-        engine.exec({script: q, context: context, connection: 'close', cb: function(err, result) {
+        engine.exec({script: q, context: context, cb: function(err, result) {
             if(err) {
                 test.fail('got error: ' + err.stack);
                 test.done();


### PR DESCRIPTION
We were doing this since node <0.6 used to keep the connection open leaving the tests hang till origin servers close connections. This is no longer required.
