### PR TITLE
Export version, and add version to Server and User-Agent headers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Feb 22, 2012
+
+* Export version from each module. You can find version of the engine using
+  `require('ql.io-engine').version`.
+* Include version number in `User-Agent` and `Server` headers.
+
 ## Feb 19, 2012
 
 * Support scatter-gather for requests with bodies by adding a `foreach 'param'` for the

--- a/modules/app/lib/main.js
+++ b/modules/app/lib/main.js
@@ -35,6 +35,8 @@ process.on('uncaughtException', function(error) {
     console.log(error.stack || error);
 });
 
+exports.version = require('../package.json').version;
+
 exports.exec = function(cb, opts) {
     var c, monPort, port, master;
 

--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-app",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/compiler/lib/compiler.js
+++ b/modules/compiler/lib/compiler.js
@@ -19,6 +19,8 @@ var ql = require('./peg/ql.js'),
 
 'use strict'
 
+exports.version = require('../package.json').version;
+
 //
 // TODO: Most of this code should move to ql.peg
 //

--- a/modules/compiler/package.json
+++ b/modules/compiler/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-compiler",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/console/app.js
+++ b/modules/console/app.js
@@ -30,6 +30,8 @@ var winston = require('winston'),
     _ = require('underscore'),
     WebSocketServer = require('websocket').server;
 
+exports.version = require('./package.json').version;
+
 process.on('uncaughtException', function(error) {
     winston.error(error.stack);
 });

--- a/modules/console/lib/middleware/respheaders.js
+++ b/modules/console/lib/middleware/respheaders.js
@@ -10,7 +10,7 @@ module.exports = function responseTime() {
 
         res.writeHead = function (status, headers) {
             res.setHeader('X-Powered-By', 'ql.io/node.js ' + process.version);
-            res.setHeader('Server', 'ql.io/node.js ' + process.version);
+            res.setHeader('Server', 'ql.io-' + require('../../package.json').version + '/node.js-' + process.version);
             res.setHeader('Date', (new Date()).toUTCString());
             res.writeHead = writeHead;
             res.writeHead(status, headers);

--- a/modules/console/package.json
+++ b/modules/console/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-console",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/ecv/lib/ecv.js
+++ b/modules/ecv/lib/ecv.js
@@ -19,6 +19,8 @@
 var http = require('http'),
     os = require('os');
 
+exports.version = require('../package.json').version;
+
 /**
  * The ECV check sends a "/tables" request to the running server. Anything other than a valid JSON response is
  * treated as an error.

--- a/modules/ecv/package.json
+++ b/modules/ecv/package.json
@@ -2,7 +2,7 @@
     "author": "ql.io",
     "description": "Provides ECV check for ql.io servers",
     "name": "ql.io-ecv",
-    "version": "0.4.2",
+    "version": "0.4.3",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/lib/engine.js
+++ b/modules/engine/lib/engine.js
@@ -42,6 +42,8 @@ var configLoader = require('./engine/config.js'),
     util = require('util'),
     assert = require('assert');
 
+exports.version = require('../package.json').version;
+
 process.on('uncaughtException', function(error) {
     winston.error(error);
 })

--- a/modules/engine/lib/engine/http.request.js
+++ b/modules/engine/lib/engine/http.request.js
@@ -211,7 +211,7 @@ function sendOneRequest(args, resourceUri, params, holder, cb) {
     };
 
     h[requestId.name]  = requestId.value;
-    h['user-agent'] = 'ql.io/node.js ' + process.version;
+    h['user-agent'] = 'ql.io-engine' + require('../../package.json').version + '/node.js-' + process.version ;
 
     // Clone headers - also replace any tokens
     _.each(resource.headers, function(v, k) {

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.4.6",
+    "version": "0.4.7",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/mutable-uri/lib/ql.uri.js
+++ b/modules/mutable-uri/lib/ql.uri.js
@@ -20,6 +20,8 @@ var _ = require('underscore'),
     url = require('url'),
     assert = require('assert');
 
+exports.version = require('../package.json').version;
+
 /**
  * You will receive an instance of ql.uri in "before request" methods.
  *

--- a/modules/mutable-uri/package.json
+++ b/modules/mutable-uri/package.json
@@ -2,7 +2,7 @@
     "author": "ql.io",
     "name": "ql.io-mutable-uri",
     "description": "A utility for manipulating URIs. This is primarily used by monkey patch files.",
-    "version": "0.4.1",
+    "version": "0.4.2",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"


### PR DESCRIPTION
- Export version from each module. You can find version of the engine using
  `require('ql.io-engine').version`.
- Include version number in `User-Agent` and `Server` headers.
