### PR TITLE
Switch to https as the scheme for the repository URL

### DIFF
--- a/modules/template/init.sh
+++ b/modules/template/init.sh
@@ -8,7 +8,7 @@
 #
 # curl "https://github.com/ql-io/ql.io/blob/master/template/init.sh" | sh
 #
-git clone git@github.com:ql-io/ql.io-template.git ql.io-template
+git clone https://github.com/ql-io/ql.io-template.git ql.io-template
 mv ql.io-template/* .
 mv ql.io-template/.gitignore .
 rm -rf ql.io-template


### PR DESCRIPTION
If github.com is not known to the client trying to clone the repo,
the user gets an interactive prompt asking them to accept the key.
This causes confusion, and breaks scripts.  The https scheme does
not have this problem.
