### PR TITLE
Simplify response decoding. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Mar 02, 2012
 
+* Simplify response decoding. In stead of setting encoding on the response, collect buffers into
+  array, and then decode in the default impl of 'parse response'. Also add tests.
 * Removed /in-flight requests api.
 
 ## Feb 28, 2012

--- a/modules/engine/lib/engine/source/verb.js
+++ b/modules/engine/lib/engine/source/verb.js
@@ -19,6 +19,7 @@
 var assert = require('assert'),
     os = require('os'),
     _ = require('underscore'),
+    headers = require('headers'),
     async = require('async'),
     MutableURI = require('ql.io-mutable-uri'),
     strTemplate = require('../peg/str-template.js'),
@@ -41,7 +42,21 @@ var Verb = module.exports = function(statement, type, bag, path) {
     this['patch headers'] = function(args) { return args.headers; };
     this['body template'] = function() {};
     this['patch body'] = function(args) { return args.body; };
-    this['parse response'] = function() {};
+    this['parse response'] = function(args) { // Just append bufs to a string
+        var encoding = 'UTF-8';
+        if(args.headers['content-type']) {
+            var contentType = headers.parse('content-type', args.headers['content-type'] || '');
+            encoding = contentType.params.charset ? contentType.params.charset :
+                contentType.subtype === 'csv' ? 'ASCII' : 'UTF-8';
+        }
+        var str = '';
+        _.each(args.body, function(buf) {
+            str += buf.toString(encoding);
+        });
+        return {
+            content: str
+        };
+    };
     this['patch response'] = function(args) {return args.body; };
     this['patch mediaType'] = function(args) { return args.headers['content-type']};
     this['patch status'] = function(args) { return args.status; };

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.4.10",
+    "version": "0.4.11",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/test/charset-encoding-test.js
+++ b/modules/engine/test/charset-encoding-test.js
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2012 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Engine = require('../lib/engine'),
+    http = require('http'),
+    util = require('util');
+
+module.exports = {
+    'json-utf8': function (test) {
+        var server = http.createServer(function (req, res) {
+            res.writeHead(200, {
+                'Content-Type': 'application/json'
+            });
+            res.write('{"message": "?????"}');
+            res.end();
+        });
+
+        server.listen(3000, function () {
+            // Do the test here.
+            var engine = new Engine({
+            });
+            var script = 'create table encoding on select get from "http://localhost:3000/"; return select * from encoding;'
+            engine.execute(script, function (emitter) {
+                emitter.on('end', function (err, result) {
+                    if(err) {
+                        console.log(err.stack || util.inspect(err, false, 10));
+                        test.fail('got error');
+                        test.done();
+                    }
+                    else {
+                        test.equals(result.headers['content-type'], 'application/json', 'json expected');
+                        test.deepEqual(result.body.message, '?????');
+                        test.done();
+                    }
+                    server.close();
+                });
+            });
+        });
+    },
+
+    'csv-utf8': function (test) {
+        var server = http.createServer(function (req, res) {
+            res.writeHead(200, {
+                'Content-Type': 'text/csv;header;charset=UTF-8'
+            });
+            res.write('name,value\nmessage,?????', 'UTF-8');
+            res.end();
+        });
+
+        server.listen(3000, function () {
+            // Do the test here.
+            var engine = new Engine({
+            });
+            var script = 'create table encoding on select get from "http://localhost:3000/"; return select * from encoding;'
+            engine.execute(script, function (emitter) {
+                emitter.on('end', function (err, result) {
+                    if(err) {
+                        console.log(err.stack || util.inspect(err, false, 10));
+                        test.fail('got error');
+                        test.done();
+                    }
+                    else {
+                        test.equals(result.headers['content-type'], 'application/json', 'json expected');
+                        test.equals(result.body[0].name, 'message');
+                        test.equals(result.body[0].value, '?????');
+                        test.done();
+                    }
+                    server.close();
+                });
+            });
+        });
+    }
+};

--- a/modules/engine/test/exec-select-for-csv-test.js
+++ b/modules/engine/test/exec-select-for-csv-test.js
@@ -16,7 +16,6 @@
 
 var _ = require('underscore'),
     Engine = require('../lib/engine'),
-    EventEmitter = require('events').EventEmitter,
     http = require('http'),
     fs = require('fs'),
     util = require('util');

--- a/modules/engine/test/patch-parse-response-test.js
+++ b/modules/engine/test/patch-parse-response-test.js
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2012 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Engine = require('../lib/engine'),
+    http = require('http'),
+    util = require('util');
+
+module.exports = {
+    'parse response': function (test) {
+        var server = http.createServer(function (req, res) {
+            res.writeHead(200, {
+                'Content-Type': 'application/binary'
+            });
+            res.write(new Buffer('[{"message": "one"},', 'UTF-8'));
+            res.write(new Buffer('{"message": "two"},', 'UTF-8'));
+            res.write(new Buffer('{"message": "three"}]', 'UTF-8'));
+            res.end();
+        });
+
+        server.listen(3000, function () {
+            // Do the test here.
+            var engine = new Engine({
+                tables: __dirname + '/patch'
+            });
+            engine.execute('select * from parse.response', function (emitter) {
+                emitter.on('end', function (err, result) {
+                    if(err) {
+                        console.log(err.stack || util.inspect(err, false, 10));
+                        test.fail('got error');
+                        test.done();
+                    }
+                    else {
+                        test.equals(result.headers['content-type'], 'application/json', 'json expected');
+                        test.deepEqual(result.body, [{message: 'one'},{message: 'two'},{message: 'three'}]);
+                        test.done();
+                    }
+                    server.close();
+                });
+            });
+        });
+    }
+};

--- a/modules/engine/test/patch/parse-response.js
+++ b/modules/engine/test/patch/parse-response.js
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2012 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var _ = require('underscore');
+
+// args.body would be an array of buffers
+exports['parse response'] = function(args) {
+    var str = '';
+    _.each(args.body, function(buf) {
+        str += buf.toString('UTF-8');
+    })
+    return {
+        type: 'application/json',
+        content: str
+    };
+}

--- a/modules/engine/test/patch/parse-response.ql
+++ b/modules/engine/test/patch/parse-response.ql
@@ -1,0 +1,2 @@
+create table parse.response on select post to 'http://localhost:3000/'
+    using patch 'parse-response.js'


### PR DESCRIPTION
In stead of setting encoding on the response, collect buffers into   array, and then decode in the default impl of 'parse response'. Also add tests.
