### PR TITLE
Recover shutdown/stop from extraneous pid files.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Mar 05, 2012
+
+* Recover shutdown/stop from extraneous pid files.
+
 ## Mar 02, 2012
 
 * Simplify response decoding. In stead of setting encoding on the response, collect buffers into

--- a/modules/app/lib/main.js
+++ b/modules/app/lib/main.js
@@ -60,9 +60,6 @@ exports.exec = function(cb, opts) {
     port = parseInt(program.port);
 
     if(program.cluster) {
-        misc.ensureDir(process.cwd() + '/pids'); // Ensure pids dir
-        misc.ensureDir(process.cwd() + '/logs'); // Ensure logs dir
-
         monPort = parseInt(program.monPort);
         master = new Master({
             pids: process.cwd() + '/pids',
@@ -223,6 +220,9 @@ function Master(options) {
 
 Master.prototype.listen = function(app, cb) {
     if(cluster.isMaster) {
+        misc.ensureDir(process.cwd() + '/pids', true); // Ensure pids dir
+        misc.ensureDir(process.cwd() + '/logs'); // Ensure logs dir
+
         this.stats.pid = process.pid;
         this.stats.start = new Date();
         this.stats.totalmem = os.totalmem();

--- a/modules/app/lib/misc.js
+++ b/modules/app/lib/misc.js
@@ -17,15 +17,23 @@
 var fs = require('fs');
 
 // Utility to ensure that certain directories exist
-exports.ensureDir = function(dir) {
+exports.ensureDir = function(dir, clean) {
     try {
         fs.readdirSync(dir);
+        if(clean) {
+            var paths = fs.readdirSync(dir);
+            paths.forEach(function(filename) {
+                try {
+                    fs.unlink(dir + '/' + filename);
+                }
+                catch(e) {}
+            });
+        }
     }
     catch(e) {
         fs.mkdirSync(dir, 0755);
     }
 }
-
 
 exports.forMemoryNum = function(memory) {
     var strMemory;

--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-app",
-    "version": "0.4.3",
+    "version": "0.4.4",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"


### PR DESCRIPTION
Fixes https://github.com/ql-io/ql.io/issues/321.

This requires manual verification
- Create an app
- mkdir pids; cd pids
- touch master.0.pid; touch worker.1.pid; touch worker.2.pid;
- cd ..
- bin/start.sh

From another shell, do a bin/stop.sh or control-C. This would bring down the server. Prior to this fix, the server would hang in there.
