### PR TITLE
Quirky XML to JSON conversions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Mar 07, 2012
 
+* Add a page showing all installed packages. Try http://<host>:<monport>/deps
+  (or http://localhost:3001/deps).
 * There are many conventions to convert xml to json. If the default xml2json does not work you, you
   can override it on table by table basis. To override, specify path to an xformers.json file. Here
   is an example.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,7 @@
   can override it on table by table basis. To override, specify path to an xformers.json file. Here
   is an example.
       {
-          "some.table" : "modulename relative to process.cwd()"
+          "some.table" : "modulename relative to process.cwd() or a module from NODE_PATH"
       }
 
 ## Mar 06, 2012

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+## Mar 07, 2012
+
+* There are many conventions to convert xml to json. If the default xml2json does not work you, you
+  can override it on table by table basis. To override, specify path to an xformers.json file. Here
+  is an example.
+      {
+          "some.table" : "modulename relative to process.cwd()"
+      }
+
 ## Mar 06, 2012
 
 * Gzip and Deflate content encoding support for upstream responses.

--- a/modules/app/lib/main.js
+++ b/modules/app/lib/main.js
@@ -337,6 +337,27 @@ Monitor.prototype.listen = function(cb) {
         }
     });
 
+    app.get('/deps', function(req, res) {
+        var npm = require('npm');
+        npm.load({}, function() {
+            npm.commands.ls({}, true, function(e, data) {
+                res.writeHead(200, {
+                    'Content-Type': 'application/json'
+                });
+
+                var seen = []
+                var out = JSON.stringify(data, function (k, o) {
+                    if(typeof o === "object") {
+                        if(-1 !== seen.indexOf(o)) return '[Circular]';
+                        seen.push(o);
+                    }
+                    return o;
+                }, 2);
+                res.end(out);
+            });
+        });
+    });
+
     app.listen(this.options.port, cb);
 
     var wsServer = new WebSocketServer({

--- a/modules/app/lib/main.js
+++ b/modules/app/lib/main.js
@@ -48,6 +48,7 @@ exports.exec = function(cb, opts) {
         option('-m, --monPort <monPort>', 'port for monitoring', 3001).
         option('-t, --tables <tables>', 'path of dir containing tables', cwd + '/../tables').
         option('-r, --routes <routes>', 'path of dir containing routes', cwd + '/../routes').
+        option('-x, --xformers <xformers>', 'path of dir containing xformers', cwd + '/../xformers').
         option('-a, --ecvPath <ecvPath>', 'ecv path', '/ecv').
         option('-e, --disableConsole', 'disable the console', false).
         option('-q, --disableQ', 'disable /q', false);
@@ -388,6 +389,7 @@ function createConsole(program, cb) {
         'tables': program.tables,
         'routes': program.routes,
         'config': program.config,
+        'xformers': program.xformers,
         'enable console': !disableConsole,
         'enable q': !disableQ,
         'log levels': require('winston').config.syslog.levels}, cb);

--- a/modules/app/lib/main.js
+++ b/modules/app/lib/main.js
@@ -46,9 +46,9 @@ exports.exec = function(cb, opts) {
         option('-c, --config <configFile>', 'path to config', cwd + '/../config/dev.json').
         option('-p, --port <port>', 'port to bind to', 3000).
         option('-m, --monPort <monPort>', 'port for monitoring', 3001).
-        option('-t, --tables <tables>', 'path of dir containing tables', cwd + '/../tables').
-        option('-r, --routes <routes>', 'path of dir containing routes', cwd + '/../routes').
-        option('-x, --xformers <xformers>', 'path of dir containing xformers', cwd + '/../xformers').
+        option('-t, --tables <tables>', 'path of dir containing tables', cwd + '/tables').
+        option('-r, --routes <routes>', 'path of dir containing routes', cwd + '/routes').
+        option('-x, --xformers <xformers>', 'path of dir containing xformers', cwd + '/config/xformers.json').
         option('-a, --ecvPath <ecvPath>', 'ecv path', '/ecv').
         option('-e, --disableConsole', 'disable the console', false).
         option('-q, --disableQ', 'disable /q', false);

--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-app",
-    "version": "0.4.5",
+    "version": "0.4.7",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"
@@ -24,7 +24,8 @@
         "mustache": "0.4.0",
         "headers": "0.9.6",
         "websocket": "1.0.4",
-        "underscore": "1.3.1"
+        "underscore": "1.3.1",
+        "npm": "1.1.1"
     },
     "devDependencies": {
         "nodeunit": "0.6.4"

--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-app",
-    "version": "0.4.4",
+    "version": "0.4.5",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/app/public/views/header.ejs
+++ b/modules/app/public/views/header.ejs
@@ -11,6 +11,9 @@
             <tr>
                 <td>PID: <%=master.pid%></td>
             </tr>
+            <tr>
+               <td><a href='/deps'>Installed modules</a></td>
+           </tr>
     </tbody>
 </table>
 

--- a/modules/console/app.js
+++ b/modules/console/app.js
@@ -82,6 +82,9 @@ var Console = module.exports = function(config, cb) {
     if(config.config) {
         logger.info('Loading config from ' + config.config);
     }
+    if(config.xformers) {
+        logger.info('Loading xformers from ' + config.xformers);
+    }
 
     var app = this.app = express.createServer();
 

--- a/modules/console/package.json
+++ b/modules/console/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-console",
-    "version": "0.4.8",
+    "version": "0.4.9",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/console/test/quirky-json/quirky.xml2json.js
+++ b/modules/console/test/quirky-json/quirky.xml2json.js
@@ -1,0 +1,6 @@
+
+exports.toJson = function(data, respCb, errorCb) {
+    return respCb({
+        "HELLO" : "WORLD"
+    });
+};

--- a/modules/console/test/quirky-json/xformers.json
+++ b/modules/console/test/quirky-json/xformers.json
@@ -1,0 +1,3 @@
+{
+    "quirky.json": "/test/quirky-json/quirky.xml2json.js"
+}

--- a/modules/console/test/test-quirky-json.js
+++ b/modules/console/test/test-quirky-json.js
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2011 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+"use strict";
+
+var http = require('http');
+
+var Console = require('../app.js');
+var c = new Console({
+    xformers: __dirname + '/quirky-json/xformers.json',
+    'enable console': false,
+    connection: 'close'
+});
+
+var app = c.app;
+
+module.exports = {
+    'quirky-json': function (test) {
+        var server = http.createServer(function (req, res) {
+            res.writeHead(200, {
+                'Content-Type': 'application/xml'
+            });
+            res.write('<hello>world</hello>');
+            res.end();
+        });
+        server.listen(3000, function () {
+            app.listen(4000, function () {
+                var script = 'create table quirky.json on select get from "http://localhost:3000"; return select * from quirky.json';
+                var options = {
+                    host: 'localhost',
+                    port: 4000,
+                    path: '/q?s=' + encodeURIComponent(script),
+                    method: 'GET',
+                    headers: {
+                        host: 'localhost',
+                        connection: 'close'
+                    }
+                };
+                var req = http.request(options, function (res) {
+                    res.setEncoding('utf8');
+                    test.equals(res.statusCode, 200);
+                    test.equals(res.headers['content-type'], 'application/json');
+                    var data = '';
+                    res.on('data', function (chunk) {
+                        data = data + chunk;
+                    })
+                    res.on('end', function () {
+                        var json = JSON.parse(data);
+                        test.deepEqual(json, { "HELLO": "WORLD"});
+                        app.close();
+                        server.close();
+                        test.done();
+                    });
+                });
+                req.end();
+            });
+        });
+    }
+};

--- a/modules/engine/lib/engine.js
+++ b/modules/engine/lib/engine.js
@@ -58,6 +58,7 @@ process.on('uncaughtException', function(error) {
  *
  */
 var Engine = module.exports = function(opts) {
+    var self = this;
 
     // Engine is a LogEmitter.
     LogEmitter.call(this);
@@ -114,11 +115,32 @@ var Engine = module.exports = function(opts) {
     });
 
     // These are transformers for data formats.
-    this.xformers = {
-        'xml' : require('./xformers/xml.js'),
-        'json' : require('./xformers/json.js'),
-        'csv' : require('./xformers/csv.js')
+    this.xformers = {};
+    if(opts.xformers) {
+        try {
+            this.xformers = require(opts.xformers);
+            _.each(this.xformers, function(v, k) {
+                if(_.isString(v)) {
+                    try {
+                        self.xformers[k] = require(process.cwd() + v);
+                    }
+                    catch(e) {
+                        delete self.xformers[k];
+                        self.emitError('Unable to load xformer ' + v);
+                    }
+                }
+                else {
+                    delete self.xformers[k];
+                }
+            })
+        }
+        catch (e) {
+            self.emitError('Unable to load xformers from ' + opts.xformers);
+        }
     }
+    this.xformers['xml'] = require('./xformers/xml.js');
+    this.xformers['json'] = require('./xformers/json.js');
+    this.xformers['csv'] = require('./xformers/csv.js');
 
     // Serializers for bodies
     this.serializers = {

--- a/modules/engine/lib/engine.js
+++ b/modules/engine/lib/engine.js
@@ -125,8 +125,13 @@ var Engine = module.exports = function(opts) {
                         self.xformers[k] = require(process.cwd() + v);
                     }
                     catch(e) {
-                        delete self.xformers[k];
-                        self.emitError('Unable to load xformer ' + v);
+                        try {
+                            self.xformers[k] = require(v);
+                        }
+                        catch(e) {
+                            delete self.xformers[k];
+                            self.emitError('Unable to load xformer ' + v);
+                        }
                     }
                 }
                 else {

--- a/modules/engine/lib/engine/http/response.js
+++ b/modules/engine/lib/engine/http/response.js
@@ -71,7 +71,7 @@ exports.exec = function(timings, reqStart, args, uniqueId, res, start, bufs, med
         util.inspect(res.headers) + ' ' + (Date.now() - start) + 'msec');
 
     // Parse
-    jsonify(respData, mediaType, res.headers, args.xformers, function (respJson) {
+    jsonify(args.table, respData, mediaType, res.headers, args.xformers, function (respJson) {
         status = args.resource.patchStatus(args.parsed, args.params, res.statusCode, res.headers, respJson || respData)
             || res.statusCode;
 
@@ -112,10 +112,13 @@ exports.exec = function(timings, reqStart, args, uniqueId, res, start, bufs, med
     });
 }
 
-function jsonify(respData, mediaType, headers, xformers, respCb, errorCb) {
+function jsonify(table, respData, mediaType, headers, xformers, respCb, errorCb) {
 
     if (!respData || /^\s*$/.test(respData)) {
         respCb({});
+    }
+    else if(xformers[table]) {
+        xformers[table].toJson(respData, respCb, errorCb, headers);
     }
     else if(mediaType.subtype === 'xml' || /\+xml$/.test(mediaType.subtype)) {
         xformers['xml'].toJson(respData, respCb, errorCb, headers);

--- a/modules/engine/lib/engine/source/table.js
+++ b/modules/engine/lib/engine/source/table.js
@@ -45,7 +45,7 @@ var Table = module.exports = function(opts, comments, statement) {
     _.each(['select', 'insert', 'update', 'delete'], function(type) {
         if(self.statement[type]) {
             try {
-                var verb = new Verb(self.statement[type], type, bag, self.opts.path);
+                var verb = new Verb(self.name, self.statement[type], type, bag, self.opts.path);
                 self.verbs[type] = verb;
             }
             catch(e) {

--- a/modules/engine/lib/engine/source/verb.js
+++ b/modules/engine/lib/engine/source/verb.js
@@ -29,7 +29,8 @@ var assert = require('assert'),
     request = require('../http/request.js'),
     _util = require('../util.js');
 
-var Verb = module.exports = function(statement, type, bag, path) {
+var Verb = module.exports = function(table, statement, type, bag, path) {
+    this.table = table;
     this.type = type;
     this.__proto__ = statement;
 
@@ -575,6 +576,7 @@ function send(verb, args, uri, params, holder, callback) {
     }
 
     request.send({
+        table: verb.table,
         config: args.config || {},
         uri: uri,
         parsed: parsed,

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.4.12",
+    "version": "0.4.13",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/test/quirky-json/quirky.xml2json.js
+++ b/modules/engine/test/quirky-json/quirky.xml2json.js
@@ -1,0 +1,6 @@
+
+exports.toJson = function(data, respCb, errorCb) {
+    return respCb({
+        "HELLO" : "WORLD"
+    });
+};

--- a/modules/engine/test/quirky-json/xformers.json
+++ b/modules/engine/test/quirky-json/xformers.json
@@ -1,0 +1,3 @@
+{
+    "quirky.json": "/test/quirky-json/quirky.xml2json.js"
+}


### PR DESCRIPTION
There are many ways to convert xml to json. If the default xml2json does not work you, you can override it on table by table basis. To override, specify path to an xformers.json file. Here is an example.

```
{
     "some.table" : "modulename relative to process.cwd()"
}
```
