### PR TITLE
Support for delete statements

### DIFF
--- a/modules/compiler/lib/peg/ql.js
+++ b/modules/compiler/lib/peg/ql.js
@@ -77,6 +77,7 @@ module.exports = (function(){
         "operator": parse_operator,
         "output": parse_output,
         "pair": parse_pair,
+        "patch": parse_patch,
         "postto": parse_postto,
         "putto": parse_putto,
         "quotedDigits": parse_quotedDigits,
@@ -1126,23 +1127,28 @@ module.exports = (function(){
         }
 
 
-        var result4 = parse_getfrom();
-        if (result4 !== null) {
-          var result0 = result4;
+        var result5 = parse_getfrom();
+        if (result5 !== null) {
+          var result0 = result5;
         } else {
-          var result3 = parse_postto();
-          if (result3 !== null) {
-            var result0 = result3;
+          var result4 = parse_postto();
+          if (result4 !== null) {
+            var result0 = result4;
           } else {
-            var result2 = parse_putto();
-            if (result2 !== null) {
-              var result0 = result2;
+            var result3 = parse_putto();
+            if (result3 !== null) {
+              var result0 = result3;
             } else {
-              var result1 = parse_delete();
-              if (result1 !== null) {
-                var result0 = result1;
+              var result2 = parse_delete();
+              if (result2 !== null) {
+                var result0 = result2;
               } else {
-                var result0 = null;;
+                var result1 = parse_patch();
+                if (result1 !== null) {
+                  var result0 = result1;
+                } else {
+                  var result0 = null;;
+                };
               };
             };
           };
@@ -1380,6 +1386,46 @@ module.exports = (function(){
         var result2 = result1 !== null
           ? (function() {
             return 'delete'
+          })()
+          : null;
+        if (result2 !== null) {
+          var result0 = result2;
+        } else {
+          var result0 = null;
+          pos = savedPos0;
+        }
+
+
+
+        cache[cacheKey] = {
+          nextPos: pos,
+          result:  result0
+        };
+        return result0;
+      }
+
+      function parse_patch() {
+        var cacheKey = 'patch@' + pos;
+        var cachedResult = cache[cacheKey];
+        if (cachedResult) {
+          pos = cachedResult.nextPos;
+          return cachedResult.result;
+        }
+
+
+        var savedPos0 = pos;
+        if (input.substr(pos, 5) === "patch") {
+          var result1 = "patch";
+          pos += 5;
+        } else {
+          var result1 = null;
+          if (reportMatchFailures) {
+            matchFailed("\"patch\"");
+          }
+        }
+        var result2 = result1 !== null
+          ? (function() {
+            return 'patch'
           })()
           : null;
         if (result2 !== null) {

--- a/modules/compiler/lib/peg/ql.js
+++ b/modules/compiler/lib/peg/ql.js
@@ -3172,7 +3172,12 @@ module.exports = (function(){
                 if (result7 !== null) {
                   var result8 = parse_insig();
                   if (result8 !== null) {
-                    var result9 = parse_whereClause();
+                    var result9 = [];
+                    var result10 = parse_whereClause();
+                    while (result10 !== null) {
+                      result9.push(result10);
+                      var result10 = parse_whereClause();
+                    }
                     if (result9 !== null) {
                       var result1 = [result3, result4, result5, result6, result7, result8, result9];
                     } else {
@@ -4604,26 +4609,43 @@ module.exports = (function(){
         }
 
 
-        var result4 = parse_aliasedRef();
-        if (result4 !== null) {
-          var result0 = result4;
+        var savedPos0 = pos;
+        var result6 = parse_aliasedRef();
+        if (result6 !== null) {
+          var result1 = result6;
         } else {
-          var result3 = parse_quotedWord();
-          if (result3 !== null) {
-            var result0 = result3;
+          var result5 = parse_quotedWord();
+          if (result5 !== null) {
+            var result1 = result5;
           } else {
-            var result2 = parse_quotedDigits();
-            if (result2 !== null) {
-              var result0 = result2;
+            var result4 = parse_quotedDigits();
+            if (result4 !== null) {
+              var result1 = result4;
             } else {
-              var result1 = parse_digits();
-              if (result1 !== null) {
-                var result0 = result1;
+              var result3 = parse_digits();
+              if (result3 !== null) {
+                var result1 = result3;
               } else {
-                var result0 = null;;
+                var result1 = null;;
               };
             };
           };
+        }
+        var result2 = result1 !== null
+          ? (function(r) {
+            if(!r.hasOwnProperty('value')) {
+              r = {
+                value: r
+              }
+            }
+            return r;
+          })(result1)
+          : null;
+        if (result2 !== null) {
+          var result0 = result2;
+        } else {
+          var result0 = null;
+          pos = savedPos0;
         }
 
 

--- a/modules/compiler/pegs/ql.peg
+++ b/modules/compiler/pegs/ql.peg
@@ -378,7 +378,7 @@ act = 'on' insig t:type insig m:actname insig u:uri insig  insig a:withAliases? 
   return ret;
 }
 
-actname = getfrom / postto / putto / delete
+actname = getfrom / postto / putto / delete / patch
 
 getfrom = 'get' insig 'from' {
   return 'get'
@@ -391,6 +391,10 @@ putto = 'put' insig 'to' {
 }
 delete = 'delete' {
   return 'delete'
+}
+
+patch = 'patch' {
+  return 'patch'
 }
 
 usingDefaults = 'using' insig 'defaults' d:nvps {

--- a/modules/compiler/pegs/ql.peg
+++ b/modules/compiler/pegs/ql.peg
@@ -541,7 +541,7 @@ insertStatement = 'insert' insig 'in' 'to' insig s:source insig '(' insig c:colu
 
 ///////////////////////////////////////////////////////////
 // delete statement
-deleteStatement = 'delete' insig 'from' insig s:source insig wc:whereClause {
+deleteStatement = 'delete' insig 'from' insig s:source insig wc:whereClause* {
   return {
     type: 'delete',
     source: s,
@@ -670,7 +670,14 @@ lhs = field
 
 operator = (insig '=' insig/ insig 'in' insig)
 
-rhs = (aliasedRef/quotedWord/quotedDigits/digits)
+rhs = r:(aliasedRef/quotedWord/quotedDigits/digits) {
+  if(!r.hasOwnProperty('value')) {
+    r = {
+      value: r
+    }
+  }
+  return r;
+}
 
 aliasedRef = chars:((selector ('.' selector)*)) {
   return {

--- a/modules/compiler/test/delete-test.js
+++ b/modules/compiler/test/delete-test.js
@@ -26,13 +26,13 @@ exports['delete'] = function (test) {
         "source": {
             "name": "foo"
         },
-        "whereCriteria": {
+        "whereCriteria": [{
             "operator": "=",
             "lhs": {name: "bar"},
             "rhs": {
                 "value": "a"
             }
-        },
+        }],
         "line": 1,
         "id": 0
     }];
@@ -47,13 +47,13 @@ exports['delete-csv'] = function (test) {
         type: 'delete',
         "source" :
             {name: 'ebay.item'},
-        whereCriteria: {
+        whereCriteria: [{
             operator: 'in',
             lhs: {name: 'itemId'},
             "rhs":{
                 value: ['180652013910', '120711247507']
             }
-        },
+        }],
         line: 1,
         id: 0
     }];

--- a/modules/compiler/test/select-test.js
+++ b/modules/compiler/test/select-test.js
@@ -785,7 +785,7 @@ module.exports = {
             test.ok(true, 'compilation did not fail');
             test.equals(cooked[0].type, 'select');
             test.ok(cooked[0].whereCriteria[0]);
-            test.equals(cooked[0].whereCriteria[0].rhs, 1234);
+            test.equals(cooked[0].whereCriteria[0].rhs.value, 1234);
             test.done();
         }
         catch(e) {
@@ -828,7 +828,9 @@ module.exports = {
             {
                 "operator": "=",
                 "lhs": {name: "products.siteid"},
-                "rhs": 0
+                "rhs": {
+                    "value": 0
+                }
             }
         ]);
         test.deepEqual(statement[0].fromClause[0], {

--- a/modules/engine/lib/engine.js
+++ b/modules/engine/lib/engine.js
@@ -531,6 +531,7 @@ function _execOne(opts, statement, cb, parentEvent) {
             break;
         case 'delete' :
             delet.exec(opts, statement, cb, parentEvent);
+            break;
         case 'show' :
             show.exec(opts, statement, cb);
             break;

--- a/modules/engine/lib/engine.js
+++ b/modules/engine/lib/engine.js
@@ -30,6 +30,7 @@ var configLoader = require('./engine/config.js'),
     create = require('./engine/create.js'),
     select = require('./engine/select.js'),
     insert = require('./engine/insert.js'),
+    delet = require('./engine/delet.js'),
     _util = require('./engine/util.js'),
     jsonfill = require('./engine/jsonfill.js'),
     eventTypes = require('./engine/event-types.js'),
@@ -528,6 +529,8 @@ function _execOne(opts, statement, cb, parentEvent) {
         case 'insert' :
             insert.exec(opts, statement, cb, parentEvent);
             break;
+        case 'delete' :
+            delet.exec(opts, statement, cb, parentEvent);
         case 'show' :
             show.exec(opts, statement, cb);
             break;
@@ -547,14 +550,13 @@ function _execOne(opts, statement, cb, parentEvent) {
             // here below is sub-optimal.
             // lhs can be a reference to an object in the context or a JS object.
             if(statement.rhs.type === 'select') {
-                select.exec(opts, statement.rhs, function(err, result) {
-                    if(err) {
-                        cb(err);
-                    }
-                    else {
-                        cb(undefined, result);
-                    }
-                });
+                select.exec(opts, statement.rhs, cb, parentEvent);
+            }
+            else if(statement.rhs.type === 'insert') {
+                insert.exec(opts, statement.rhs, cb, parentEvent);
+            }
+            else if(statement.rhs.type === 'delete') {
+                delet.exec(opts, statement.rhs, cb, parentEvent);
             }
             else {
                 lhs = statement.rhs.ref ? opts.context[statement.rhs.ref] : statement.rhs.object;

--- a/modules/engine/lib/engine/delet.js
+++ b/modules/engine/lib/engine/delet.js
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2012 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var filter = require('./filter.js'),
+    where = require('./where.js'),
+    _ = require('underscore'),
+    assert = require('assert');
+
+exports.exec = function (opts, statement, cb, parentEvent) {
+
+    assert.ok(opts.tables, 'Argument tables can not be undefined');
+    assert.ok(statement, 'Argument statement can not be undefined');
+    assert.ok(cb, 'Argument cb can not be undefined');
+    assert.ok(opts.xformers, 'No xformers set');
+
+    var deleteEvent = opts.logEmitter.wrapEvent(parentEvent, 'QlIoDelete', null, cb);
+
+    var tables = opts.tables, tempResources = opts.tempResources, context = opts.context,
+        request = opts.request, emitter = opts.emitter;
+    var deleteExecTx = opts.logEmitter.wrapEvent(deleteEvent.event, 'QlIoDeleteExec', null, function (err, results) {
+        return deleteEvent.cb(err, results);
+    });
+
+    //
+    // Analyze where conditions and fetch any dependent data
+    var params, i, r, p, max, resource, apiTx;
+    where.exec(opts, statement.whereCriteria, function (err, results) {
+        // Results should now have the params for executing the delete.
+
+        // Reorder results - results is an array of objects, but we just want an object
+        params = {};
+        for(i = 0, max = results.length; i < max; i++) {
+            r = results[i];
+            for(p in r) {
+                if(r.hasOwnProperty(p)) {
+                    params[p] = r[p];
+                }
+            }
+        }
+
+        var name = statement.source.name;
+
+        // Lookup context for the source - we do this since the compiler puts the name in
+        // braces to denote the source as a variable and not a table.
+        if(name.indexOf("{") === 0 && name.indexOf("}") === name.length - 1) {
+            name = name.substring(1, name.length - 1);
+        }
+        resource = context[name];
+        if(context.hasOwnProperty(name)) { // The value may be null/undefined, and hence the check the property
+            apiTx = opts.logEmitter.wrapEvent(deleteExecTx.event, 'API', name, deleteExecTx.cb);
+
+            if(_.isArray(resource)) {
+                resource = filter.reject(resource, statement, context, statement.source);
+            }
+            else if(_.isObject(resource)) {
+                _.each(params, function(val, key) {
+                    if(resource.hasOwnProperty(key) && resource[key] === val) {
+                        delete resource[key];
+                    }
+                });
+            }
+
+            if(statement.assign) {
+                context[statement.assign] = resource;
+                emitter.emit(statement.assign, resource);
+            }
+            return apiTx.cb(null, {
+                headers: {
+                    'content-type': 'application/json'
+                },
+                body: resource
+            });
+        }
+        else {
+            // Get the resource
+            resource = tempResources[name] || tables[name];
+            apiTx = opts.logEmitter.wrapEvent(deleteExecTx.event, 'API', name, deleteExecTx.cb);
+            if(!resource) {
+                return apiTx.cb('No such table ' + name);
+            }
+            var verb = resource.verb('delete');
+            if(!verb) {
+                return apiTx.cb('Table ' + name + ' does not support select');
+            }
+            // Limit and offset
+            verb.exec({
+                context: opts.context,
+                config: opts.config,
+                settings: opts.settings,
+                resource: verb,
+                xformers: opts.xformers,
+                serializers: opts.serializers,
+                params: params,
+                request: request,
+                statement: statement,
+                emitter: emitter,
+                logEmitter: opts.logEmitter,
+                parentEvent: apiTx.event,
+                callback: function (err, result) {
+                    if(result) {
+                        context[statement.assign] = result.body;
+                        emitter.emit(statement.assign, result.body);
+                    }
+                    return apiTx.cb(err, result);
+                }
+            });
+        }
+    });
+};

--- a/modules/engine/lib/engine/filter.js
+++ b/modules/engine/lib/engine/filter.js
@@ -53,14 +53,19 @@ function _iterate(resource, statement, context, source, keep) {
 
     // Initially, everything is a match. We then iteratively reduce the set.
     var filtered = [];
-    var matched = [];
-    for(i = 0; i < resource.length; i++) {
-        matched.push(i);
-    }
     // All and conditions should match. If the RHS of a condition
     // has multiple values, they are ORed.
     //
     if(statement.whereCriteria && statement.whereCriteria.length > 0) {
+        // Wrap into an array if source is not an array. Otherwise we will end up
+        // iterating over its props
+        filtered = _.isArray(resource) ? resource : [resource];
+
+        var matched = [];
+        for(i = 0; i < filtered.length; i++) {
+            matched.push(i);
+        }
+
         for(i = 0; i < statement.whereCriteria.length; i++) {
             var cond = statement.whereCriteria[i];
             var expected = expecteds[i];
@@ -72,7 +77,7 @@ function _iterate(resource, statement, context, source, keep) {
             var _matched = [];
             for(var k = 0; k < matched.length; k++) {
                 var match = false;
-                var row = resource[matched[k]];
+                var row = filtered[matched[k]];
                 var result = jsonPath.eval(row, path, {flatten: true});
                 // If the result matches any expected[], keep it.
                 for(j = 0; j < expected.length; j++) {
@@ -86,14 +91,16 @@ function _iterate(resource, statement, context, source, keep) {
             }
             matched = _matched;
         }
-        for(i = 0; i < resource.length; i++) {
+        var ret = [];
+        for(i = 0; i < filtered.length; i++) {
             if(keep && _.contains(matched, i)) {
-                filtered.push(resource[i]);
+                ret.push(resource[i]);
             }
             else if (!keep && !_.contains(matched, i)) {
-                filtered.push(resource[i]);
+                ret.push(resource[i]);
             }
         }
+        filtered = ret;
     }
     else {
         // If there are no where conditions, use the original

--- a/modules/engine/lib/engine/filter.js
+++ b/modules/engine/lib/engine/filter.js
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2012 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict'
+
+var jsonfill = require('./jsonfill.js'),
+    _ = require('underscore'),
+    jsonPath = require('JSONPath'),
+    assert = require('assert');
+
+exports.reject = function(resource, statement, context, source) {
+    return _iterate(resource, statement, context, source, false);
+};
+
+exports.filter = function(resource, statement, context, source) {
+    return _iterate(resource, statement, context, source, true);
+};
+
+function _iterate(resource, statement, context, source, keep) {
+    var i, j;
+    resource = jsonfill.unwrap(resource);
+
+    // Local filtering (rudimentary)
+    // Prep expected once
+    var expecteds = _.map(statement.whereCriteria, function (cond) {
+        var expected = [];
+        if(cond.operator === 'in') {
+            _.each(cond.rhs.value, function (val) {
+                expected = expected.concat(jsonfill.fill(val, context));
+            });
+        }
+        else if(cond.operator === '=') {
+            expected = expected.concat(jsonfill.fill(cond.rhs.value, context));
+        }
+        else {
+            assert.ok(cond.operator === '=', 'Local filtering supported for = only');
+        }
+        return expected;
+    });
+    // Wrap into an array if source is not an array. Otherwise we will end up
+    // iterating over its props.
+    var filtered = [];
+    if(statement.whereCriteria && statement.whereCriteria.length > 0) {
+        filtered = _.isArray(resource) ? resource : [resource];
+        // All and conditions should match. If the RHS of a condition
+        // has multiple values, they are ORed.
+        //
+        for(i = 0; i < statement.whereCriteria.length; i++) {
+            var cond = statement.whereCriteria[i];
+            var expected = expecteds[i];
+            var path = cond.lhs.name;
+            if(path.indexOf(source.alias + '.') === 0) {
+                path = path.substr(source.alias.length + 1);
+            }
+
+            var op = keep ? _.filter : _.reject
+            filtered = op(filtered, function (row) {
+                var matched = false;
+                var result = jsonPath.eval(row, path, {flatten: true});
+                // If the result matches any expected[], keep it.
+                for(j = 0; j < expected.length; j++) {
+                    if(!matched && result && _.isArray(result) && result.length == 1 && result[0] == expected[j]) {
+                        matched = true;
+                    }
+                }
+                return matched;
+            });
+        }
+    }
+    else {
+        // If there are no where conditions, use the original
+        filtered = keep ? resource : [];
+    }
+    return filtered;
+}

--- a/modules/engine/lib/engine/http/request.js
+++ b/modules/engine/lib/engine/http/request.js
@@ -75,7 +75,7 @@ exports.send = function(args) {
 }
 
 function sendMessage(args, client, options, retry) {
-    var status, clientRequest, start = Date.now(), mediaType, respData, uri;
+    var status, clientRequest, start = Date.now(), mediaType, uri;
     var reqStart = Date.now();
     var timings = {
         "blocked": -1,

--- a/modules/engine/lib/engine/project.js
+++ b/modules/engine/lib/engine/project.js
@@ -27,7 +27,7 @@ function run(resultSet, statement, results, cb) {
 
     // Find the row-equivalent from the representation
     obj = select(resultSet, results);
-    if(statement.columns.name === '*' || statement.type === 'insert' ||
+    if(!statement.columns || statement.columns.name === '*' || statement.type === 'insert' ||
         (_.isArray(obj) && obj.length === 0) || // Skip these cases - there is nothing to project
         !obj) {
         // Can't filter non-array results

--- a/modules/engine/lib/engine/source/verb.js
+++ b/modules/engine/lib/engine/source/verb.js
@@ -562,7 +562,7 @@ function send(verb, args, uri, params, callback) {
 
     // Body
     var body;
-    if(args.resource.method === 'post' || args.resource.method == 'put') {
+    if(args.resource.method === 'post' || args.resource.method === 'put' || args.resource.method === 'delete' || args.resource.method === 'patch') {
         var payload = args.resource.tmpl(parsed, params, headers, args.serializers);
         body = payload.content;
         if(body) {

--- a/modules/engine/lib/engine/source/verb.js
+++ b/modules/engine/lib/engine/source/verb.js
@@ -303,7 +303,7 @@ var Verb = module.exports = function(table, statement, type, bag, path) {
                         }
                         rem[args.resource.body.foreach] = param;
                         // TODO: merge rem and holder into one
-                        send(self, args, resourceUri[0], rem, holder, function (e, r) {
+                        send(self, args, resourceUri[0], rem, function (e, r) {
                             callback(e, r);
                         });
                     }
@@ -314,7 +314,7 @@ var Verb = module.exports = function(table, statement, type, bag, path) {
             _.each(resourceUri, function (uri) {
                 tasks.push(function (uri) {
                     return function (callback) {
-                        send(self, args, uri, params, holder, function (e, r) {
+                        send(self, args, uri, params, function (e, r) {
                             callback(e, r);
                         });
                     }
@@ -510,9 +510,7 @@ function cloneDeep(obj) {
     return copy;
 }
 
-function send(verb, args, uri, params, holder, callback) {
-    var util = require('util');
-
+function send(verb, args, uri, params, callback) {
     // Authenticate the request
     if(verb.auth) {
         verb.auth.auth(params, args.config, function (err) {

--- a/modules/engine/lib/engine/util.js
+++ b/modules/engine/lib/engine/util.js
@@ -42,3 +42,17 @@ exports.prepareParams = function() {
     return params;
 }
 
+
+var maxRequests;
+exports.getMaxRequests = function(config, logEmitter) {
+    if (config && config.maxNestedRequests) {
+        maxRequests = config.maxNestedRequests;
+    }
+
+    if (!maxRequests) {
+        maxRequests = 50;
+        logEmitter.emitWarning('config.maxNestedRequests is undefined! Defaulting to ' + maxRequests);
+    }
+
+    return maxRequests;
+}

--- a/modules/engine/lib/engine/where.js
+++ b/modules/engine/lib/engine/where.js
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2012 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var jsonfill = require('./jsonfill.js'),
+    async = require('async'),
+    _util = require('./util.js'),
+    _ = require('underscore'),
+    select = require('./select.js');
+
+//
+// Preps the where clause, once done hands off to cb
+//
+exports.exec = function(opts, where, cb, parentEvent) {
+    var context = opts.context, key;
+
+    var selectExecTx = opts.logEmitter.wrapEvent(parentEvent, 'QlIoSelectExec', null, cb);
+    //
+    // Analyze where conditions and fetch any dependent data
+    var name, ret, i, r, max;
+    var tasks = [];
+    _.each(where, function(cond) {
+        if(cond.operator === '=') {
+            name = cond.lhs.name;
+            //
+            // This is a string value. No need to do any remote fetch.
+            // This is a curry. There are more curried functions below. If you don't know
+            // what currying is, don't touch this code unless you read Crockford's book.
+            tasks.push(function(cond, name) {
+                return function(callback) {
+                    ret = {};
+                    key = (cond.rhs.value !== undefined) ? cond.rhs.value : cond.rhs;
+                    ret[name] = jsonfill.lookup(key, context);
+                    callback(null, ret);
+                };
+            }(cond, name));
+        }
+        //
+        // This is an IN condition. RHS could be a comma separated values or a SELECT
+        else if(cond.operator === 'in') {
+            name = cond.lhs.name;
+            if(cond.rhs.fromClause) {
+                tasks.push(function(cond, name) {
+                    return function(callback) {
+                        select.exec(opts, cond.rhs, function(e, r) {
+                            if(e) {
+                                callback(e);
+                            }
+                            else {
+                                ret = {};
+                                ret[name] = r.body;
+                                callback(null, ret);
+                            }
+                        }, selectExecTx.event);
+                    };
+                }(cond, name));
+            }
+            else if(_.isArray(cond.rhs.value)) {
+                tasks.push(function(cond, name) {
+                    return function(callback) {
+                        ret = {};
+                        ret[name] = [];
+
+                        // Determine whether the number of values is within the limit and prune the values array
+                        var maxRequests = _util.getMaxRequests(opts.config, opts.logEmitter);
+                        if (cond.rhs.value.length > maxRequests) {
+                            opts.logEmitter.emitWarning('Pruning the number of nested requests in in-clause to config.maxNestedRequests = ' + maxRequests + '.');
+                            cond.rhs.value = cond.rhs.value.slice(0, maxRequests);
+                        }
+
+                        // Expand variables from context
+                        _.each(cond.rhs.value, function(key) {
+                            var arr = jsonfill.lookup(key, context);
+                            if(_.isArray(arr)) {
+                                _.each(arr, function(v) {
+                                    ret[name].push(v);
+                                });
+                            }
+                            else {
+                                ret[name].push(arr);
+                            }
+                        });
+                        callback(null, ret);
+                    };
+                }(cond, name));
+            }
+        }
+    });
+
+    // Run tasks asynchronously and join on the callback. On completion, the results array will
+    // have the values to execute this statement
+    async.parallel(tasks, function(err, results) {
+            cb(err, results);
+    });
+}

--- a/modules/engine/test/delete-test.js
+++ b/modules/engine/test/delete-test.js
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2012 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Engine = require('../lib/engine'),
+    http = require('http'),
+    util = require('util');
+
+module.exports = {
+    'delete obj': function (test) {
+        var script = 'obj = {\
+            "a" : "A",\
+            "b" : "B",\
+            "c" : "C"\
+        }\
+        return delete from obj where a = "A";';
+        var engine = new Engine();
+        engine.execute(script, function (emitter) {
+            emitter.on('end', function (err, result) {
+                if(err) {
+                    console.log(err.stack || util.inspect(err, false, 10));
+                    test.fail('got error');
+                    test.done();
+                }
+                else {
+                    test.equals(result.headers['content-type'], 'application/json', 'json expected');
+                    test.equals(result.body.a, undefined);
+                    test.equals(result.body.b, 'B');
+                    test.equals(result.body.c, 'C');
+                    test.done();
+                }
+            });
+        });
+    },
+    'delete arr': function (test) {
+        var script = 'arr = [\
+            {"key" : 1},\
+            {"key" : 2},\
+            {"key" : 3},\
+            {"key" : 4}]\
+            narr = delete from arr where key = 1;\
+            return narr;';
+        var engine = new Engine();
+        engine.execute(script, function (emitter) {
+            emitter.on('end', function (err, result) {
+                if(err) {
+                    console.log(err.stack || util.inspect(err, false, 10));
+                    test.fail('got error');
+                    test.done();
+                }
+                else {
+                    test.equals(result.headers['content-type'], 'application/json', 'json expected');
+                    test.equals(result.body.length, 3);
+                    test.deepEqual(result.body, [
+                        {
+                            "key": 2
+                        },
+                        {
+                            "key": 3
+                        },
+                        {
+                            "key": 4
+                        }
+                    ]);
+                    test.done();
+                }
+            });
+        });
+    },
+    'delete arr ret': function (test) {
+        var script = 'arr = [\
+            {"key" : 1},\
+            {"key" : 2},\
+            {"key" : 3},\
+            {"key" : 4}]\
+            return delete from arr where key = 1;';
+        var engine = new Engine();
+        engine.execute(script, function (emitter) {
+            emitter.on('end', function (err, result) {
+                if(err) {
+                    console.log(err.stack || util.inspect(err, false, 10));
+                    test.fail('got error');
+                    test.done();
+                }
+                else {
+                    test.equals(result.headers['content-type'], 'application/json', 'json expected');
+                    test.equals(result.body.length, 3);
+                    test.deepEqual(result.body, [
+                        {
+                            "key": 2
+                        },
+                        {
+                            "key": 3
+                        },
+                        {
+                            "key": 4
+                        }
+                    ]);
+                    test.done();
+                }
+            });
+        });
+    },
+    'delete': function (test) {
+        test.done();
+//        var server = http.createServer(function (req, res) {
+//            res.writeHead(200, {
+//                'Content-Type': 'application/json'
+//            });
+//            util.pump(req, res, function (e) {
+//                if(e) {
+//                    console.log(e.stack || e);
+//                }
+//                res.end();
+//            });
+//        });
+//        server.listen(3000, function () {
+//            // Do the test here.
+//            var engine = new Engine({
+//                tables: __dirname + '/insert'
+//            });
+//            engine.execute('delete insert.into (name) values ("hello")', function (emitter) {
+//                emitter.on('end', function (err, result) {
+//                    if(err) {
+//                        console.log(err.stack || util.inspect(err, false, 10));
+//                        test.fail('got error');
+//                        test.done();
+//                    }
+//                    else {
+//                        test.equals(result.headers['content-type'], 'application/json', 'json expected');
+//                        test.equals(result.body.name, 'hello');
+//                        test.done();
+//                    }
+//                    server.close();
+//                });
+//            });
+//        });
+    }
+};

--- a/modules/engine/test/delete-test.js
+++ b/modules/engine/test/delete-test.js
@@ -44,14 +44,14 @@ module.exports = {
             });
         });
     },
-    'delete arr': function (test) {
+    'delete arr and': function (test) {
         var script = 'arr = [\
-            {"key" : 1},\
-            {"key" : 2},\
-            {"key" : 3},\
-            {"key" : 4}]\
-            narr = delete from arr where key = 1;\
-            return narr;';
+                    {"key" : 1, "color": "red"},\
+                    {"key" : 2, "color": "green"},\
+                    {"key" : 3, "color": "red"},\
+                    {"key" : 4}]\
+                    narr = delete from arr where key = 1 and color = "red";\
+                    return narr;';
         var engine = new Engine();
         engine.execute(script, function (emitter) {
             emitter.on('end', function (err, result) {
@@ -65,10 +65,82 @@ module.exports = {
                     test.equals(result.body.length, 3);
                     test.deepEqual(result.body, [
                         {
-                            "key": 2
+                            "key": 2, "color": "green"
                         },
                         {
-                            "key": 3
+                            "key": 3, "color": "red"
+                        },
+                        {
+                            "key": 4
+                        }
+                    ]);
+                    test.done();
+                }
+            });
+        });
+    },
+    'delete arr and multival': function (test) {
+        var script = 'colors = ["red", "green"];\
+                arr = [\
+                {"key" : 1, "color": "red"},\
+                {"key" : 2, "color": "green"},\
+                {"key" : 3, "color": "red"},\
+                {"key" : 4}]\
+                narr = delete from arr where key = 1 and color = "{colors}";\
+                return narr;';
+        var engine = new Engine();
+        engine.execute(script, function (emitter) {
+            emitter.on('end', function (err, result) {
+                if(err) {
+                    console.log(err.stack || util.inspect(err, false, 10));
+                    test.fail('got error');
+                    test.done();
+                }
+                else {
+                    test.equals(result.headers['content-type'], 'application/json', 'json expected');
+                    test.equals(result.body.length, 3);
+                    test.deepEqual(result.body, [
+                        {
+                            "key": 2, "color": "green"
+                        },
+                        {
+                            "key": 3, "color": "red"
+                        },
+                        {
+                            "key": 4
+                        }
+                    ]);
+                    test.done();
+                }
+            });
+        });
+    },
+    'delete arr and in': function (test) {
+        var script = 'colors = ["red", "green"];\
+                    arr = [\
+                    {"key" : 1, "color": "red"},\
+                    {"key" : 2, "color": "green"},\
+                    {"key" : 3, "color": "red"},\
+                    {"key" : 4}]\
+                    narr = delete from arr where key = 1 and color in "{colors}";\
+                    return narr;';
+        var engine = new Engine();
+        engine.execute(script, function (emitter) {
+            emitter.on('end', function (err, result) {
+                if(err) {
+                    console.log(err.stack || util.inspect(err, false, 10));
+                    test.fail('got error');
+                    test.done();
+                }
+                else {
+                    test.equals(result.headers['content-type'], 'application/json', 'json expected');
+                    test.equals(result.body.length, 3);
+                    test.deepEqual(result.body, [
+                        {
+                            "key": 2, "color": "green"
+                        },
+                        {
+                            "key": 3, "color": "red"
                         },
                         {
                             "key": 4
@@ -114,38 +186,37 @@ module.exports = {
         });
     },
     'delete': function (test) {
-        test.done();
-//        var server = http.createServer(function (req, res) {
-//            res.writeHead(200, {
-//                'Content-Type': 'application/json'
-//            });
-//            util.pump(req, res, function (e) {
-//                if(e) {
-//                    console.log(e.stack || e);
-//                }
-//                res.end();
-//            });
-//        });
-//        server.listen(3000, function () {
-//            // Do the test here.
-//            var engine = new Engine({
-//                tables: __dirname + '/insert'
-//            });
-//            engine.execute('delete insert.into (name) values ("hello")', function (emitter) {
-//                emitter.on('end', function (err, result) {
-//                    if(err) {
-//                        console.log(err.stack || util.inspect(err, false, 10));
-//                        test.fail('got error');
-//                        test.done();
-//                    }
-//                    else {
-//                        test.equals(result.headers['content-type'], 'application/json', 'json expected');
-//                        test.equals(result.body.name, 'hello');
-//                        test.done();
-//                    }
-//                    server.close();
-//                });
-//            });
-//        });
+        var server = http.createServer(function (req, res) {
+            res.writeHead(200, {
+                'Content-Type': 'application/json'
+            });
+            util.pump(req, res, function (e) {
+                if(e) {
+                    console.log(e.stack || e);
+                }
+                res.end();
+            });
+        });
+        server.listen(3000, function () {
+            // Do the test here.
+            var engine = new Engine({
+                tables: __dirname + '/delete'
+            });
+            engine.execute('delete from delete.test where name = 101', function (emitter) {
+                emitter.on('end', function (err, result) {
+                    if(err) {
+                        console.log(err.stack || util.inspect(err, false, 10));
+                        test.fail('got error');
+                        test.done();
+                    }
+                    else {
+                        test.equals(result.headers['content-type'], 'application/json', 'json expected');
+                        test.equals(result.body.name, 101);
+                        test.done();
+                    }
+                    server.close();
+                });
+            });
+        });
     }
 };

--- a/modules/engine/test/delete/delete.json.mu
+++ b/modules/engine/test/delete/delete.json.mu
@@ -1,0 +1,5 @@
+{
+  {{#params}}
+  "name" : "{{name}}"
+  {{/params}}
+}

--- a/modules/engine/test/delete/delete.ql
+++ b/modules/engine/test/delete/delete.ql
@@ -1,0 +1,3 @@
+create table delete.test
+    on delete delete 'http://localhost:3000/'
+        using bodyTemplate 'delete.json.mu' type 'application/json'


### PR DESCRIPTION
1. Add support for delete statements in the engine.
2. Refactor select to move where clause handling and local filtering into separate modules as they are shared between all statements that support where clauses.
3. Fix a bug in the peg for delete statements which prevented multiple conditions in the where clause
