### PR TITLE
Update max listeners

### DIFF
--- a/modules/engine/lib/engine.js
+++ b/modules/engine/lib/engine.js
@@ -68,7 +68,7 @@ var Engine = module.exports = function(opts) {
 
     opts.logger = opts.logger || new (winston.Logger)();
     // Attach listeners and loggers before doing anything
-    this.setMaxListeners(25);
+    this.setMaxListeners(30);
     this.on(Engine.Events.EVENT, function(event, message) {
         if(message) {
             opts.logger.info(new Date() + ' - ' + message);

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.4.25",
+    "version": "0.4.26",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"


### PR DESCRIPTION
Seeing

warning: possible EventEmitter memory leak detected. 25 listeners added. Use emitter.setMaxListeners() to increase limit.

on CI.
