### PR TITLE
Deal with alias names used with joins and UDFs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Apr 11, 2012
+
+* Fix the case of alias names with joins and UDFs.
+
 ## Apr 08, 2012
 
 * Support null values in Values

--- a/modules/engine/lib/engine/udf.js
+++ b/modules/engine/lib/engine/udf.js
@@ -139,7 +139,9 @@ function resolve(opts, columns, extras, udf, tempNames, tempIndices) {
                 if(udf.args[0] && udf.args[0].alias) {
                     _row = row;
                     _.each(extras, function(extra) {
-                        delete _row[columns[extra].alias];
+                        if(_row[columns[extra]] && _row[columns[extra].alias]) {
+                            delete _row[columns[extra].alias];
+                        }
                     });
                 }
                 else {

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.5.3",
+    "version": "0.5.4",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/test/udfs/args.js
+++ b/modules/engine/test/udfs/args.js
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-var util = require('util');
+var util = require('util'),
+    _ = require('underscore');
+
 exports.echo = function() {
     return this.next(null, Array.prototype.slice.call(arguments));
 }
@@ -25,6 +27,15 @@ exports.thru = function() {
 
 exports.append = function() {
     this.row = this.row.concat(Array.prototype.slice.call(arguments));
+    return this.next(null, this.row);
+}
+
+exports.appendFields = function() {
+    var args = Array.prototype.slice.call(arguments);
+    var self = this;
+    _.each(args, function(arg, i) {
+        self.row['arg' + i] = arg;
+    });
     return this.next(null, this.row);
 }
 

--- a/modules/engine/test/where-join-udf-test.js
+++ b/modules/engine/test/where-join-udf-test.js
@@ -76,6 +76,40 @@ module.exports = {
         });
     },
 
+    'join-cols-as-args-with-aliases': function(test) {
+        var script = 'u = require("./test/udfs/args.js");\
+                          a1 = [{"name": "Brand-A", "keys" : [{ "name": "G1"},{"name": "G2"},{"name": "G3"}]},\
+                                {"name": "Brand-B", "keys" : [{ "name": "G1"},{"name": "G2"}]},\
+                                {"name": "Brand-C", "keys" : [{ "name": "G4"},{"name": "G2"}]}];\
+                          a2 = [{"name": "Brand-A", "details": [{"name": "G3","count": 32},{"name": "G5","count": 18}]},\
+                                {"name": "Brand-C", "details": [{"name": "G3","count": 32}, {"name": "G5","count": 18}]}];\
+                          return select a2.details as details from a1 as a1, a2 as a2 where a1.name = a2.name and u.appendFields(a1.name, a2.name)';
+        engine.execute(script, function (emitter) {
+            emitter.on('end', function (err, results) {
+                if(err) {
+                    console.log(err.stack || err);
+                    test.ok(false);
+                    test.done();
+                }
+                else {
+                    test.deepEqual(results.body[0].details, [
+                        { name: 'G3', count: 32 },
+                        { name: 'G5', count: 18 }
+                    ]);
+                    test.deepEqual(results.body[0].arg0, 'Brand-A');
+                    test.deepEqual(results.body[0].arg1, 'Brand-A');
+                    test.deepEqual(results.body[1].details, [
+                        { name: 'G3', count: 32 },
+                        { name: 'G5', count: 18 }
+                    ]);
+                    test.deepEqual(results.body[1].arg0, 'Brand-C');
+                    test.deepEqual(results.body[1].arg1, 'Brand-C');
+                    test.done();
+                }
+            })
+        });
+    },
+
     'join-cols-as-args-plus-one': function(test) {
         var script = 'u = require("./test/udfs/args.js");\
                       a1 = [{"name": "Brand-A", "keys" : [{ "name": "G1"},{"name": "G2"},{"name": "G3"}]},\
@@ -103,6 +137,49 @@ module.exports = {
                     test.deepEqual(results.body[1][1], 'Brand-C');
                     test.deepEqual(results.body[1][2], 'Brand-C');
                     test.deepEqual(results.body[1][3], [{ "name": "G4"},{"name": "G2"}]);
+                    test.done();
+                }
+            })
+        });
+    },
+
+    'join-cols-as-args-plus-one-with-alias': function (test) {
+        var script = 'u = require("./test/udfs/args.js");\
+                          a1 = [{"name": "Brand-A", "keys" : [{ "name": "G1"},{"name": "G2"},{"name": "G3"}]},\
+                                {"name": "Brand-B", "keys" : [{ "name": "G1"},{"name": "G2"}]},\
+                                {"name": "Brand-C", "keys" : [{ "name": "G4"},{"name": "G2"}]}];\
+                          a2 = [{"name": "Brand-A", "details": [{"name": "G3","count": 32},{"name": "G5","count": 18}]},\
+                                {"name": "Brand-C", "details": [{"name": "G3","count": 32}, {"name": "G5","count": 18}]}];\
+                          return select a2.details as details from a1 as a1, a2 as a2 where a1.name = a2.name and u.appendFields(a1.name, a2.name, a1.keys)';
+        engine.execute(script, function (emitter) {
+            emitter.on('end', function (err, results) {
+                if(err) {
+                    console.log(err.stack || err);
+                    test.ok(false);
+                    test.done();
+                }
+                else {
+                    test.deepEqual(results.body[0].details, [
+                        { name: 'G3', count: 32 },
+                        { name: 'G5', count: 18 }
+                    ]);
+                    test.deepEqual(results.body[0].arg0, 'Brand-A');
+                    test.deepEqual(results.body[0].arg1, 'Brand-A');
+                    test.deepEqual(results.body[0].arg2, [
+                        { "name": "G1"},
+                        {"name": "G2"},
+                        {"name": "G3"}
+                    ]);
+                    test.deepEqual(results.body[1].details, [
+                        { name: 'G3', count: 32 },
+                        { name: 'G5', count: 18 }
+                    ]);
+                    test.deepEqual(results.body[1].arg0, 'Brand-C');
+                    test.deepEqual(results.body[1].arg1, 'Brand-C');
+                    test.deepEqual(results.body[1].arg2, [
+                        { "name": "G4"},
+                        {"name": "G2"}
+                    ]);
                     test.done();
                 }
             })


### PR DESCRIPTION
TypeError: Cannot read property 'alias' of undefined
    at /Users/subrah/dev/ql.io-public/modules/engine/lib/engine/udf.js:143:51
    at Array.forEach (native)
    at Function.<anonymous> (/Users/subrah/dev/ql.io-public/modules/engine/node_modules/underscore/underscore.js:76:11)
