### PR TITLE
Fix string tokenizer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Apr 24, 2012
+
+* Fix expression parsing in string template so that a token like `"{obj.prop[?(@.price > 2)]}"` is
+  valid
+
 ## Apr 20, 2012
 
 * Add support for escaped quotes in string values

--- a/modules/engine/lib/engine/peg/str-template.js
+++ b/modules/engine/lib/engine/peg/str-template.js
@@ -145,13 +145,13 @@ module.exports = (function(){
       function parse_literal() {
         var result0;
 
-        if (/^[^^ "'<>`{}]/.test(input.charAt(pos))) {
+        if (/^[^^`{}]/.test(input.charAt(pos))) {
           result0 = input.charAt(pos);
           pos++;
         } else {
           result0 = null;
           if (reportFailures === 0) {
-            matchFailed("[^^ \"'<>`{}]");
+            matchFailed("[^^`{}]");
           }
         }
         if (result0 === null) {

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.5.14",
+    "version": "0.5.15",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/engine/pegs/str-template.peg
+++ b/modules/engine/pegs/str-template.peg
@@ -169,4 +169,4 @@ digits = d:[0-9]* {
         str += d[i];
     }
     return str;
-}N
+}

--- a/modules/engine/pegs/str-template.peg
+++ b/modules/engine/pegs/str-template.peg
@@ -137,7 +137,7 @@ template = c:( expression / literal )* {
     }
 }
 
-literal = (([^^ "'<>\`{}]) / ' ') / expression
+literal = (([^^\`{}]) / ' ') / expression
 
 expression =  "{" v:variable "}" {
     var token = {
@@ -169,4 +169,4 @@ digits = d:[0-9]* {
         str += d[i];
     }
     return str;
-}
+}N

--- a/modules/engine/test/jsonpath-expr-test.js
+++ b/modules/engine/test/jsonpath-expr-test.js
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2011 eBay Software Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+var Engine = require('../lib/engine');
+
+var engine = new Engine();
+
+module.exports = {
+    'expr?': function(test) {
+        var script = 'obj = {\
+                                "prop" : [\
+                                    {"name": "A", "price": "1.95"},\
+                                    {"name": "B", "price": "2.95"},\
+                                    {"name": "C", "price": "3.95"}\
+                                ]\
+                        };\
+                      return "{obj.prop[?(@.price > 2)]}";';
+        engine.execute(script, function(emitter) {
+            emitter.on('end', function(err, result) {
+                if(err) {
+                    test.fail('got error: ' + err.stack);
+                    test.done();
+                }
+                else {
+                    test.equal(result.body.length, 2);
+                    test.equal(result.body[0].name, 'B');
+                    test.equal(result.body[0].price, '2.95');
+                    test.equal(result.body[1].name, 'C');
+                    test.equal(result.body[1].price, '3.95');
+                    test.done();
+                }
+            });
+        });
+    }
+};


### PR DESCRIPTION
```
obj = {
      'prop' : [
         {'name': 'A', 'price': '1.95'},
         {'name': 'B', 'price': '2.95'},
         {'name': 'C', 'price': '3.95'}
      ]
};

return "{obj.prop[?(@.price > 2)]}";
```

now works as expected.
