### PR TITLE
Disable ability to enable/disable ecv checks by default

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
+## May 18, 2012
+
+* Disable ability to enable/disable ecv checks by default. You can turn it on by adding arg
+   `--ecvControl true` to the start script.
+
 ## May 17, 2012
 
-* Add optional parameters in route. Including "with optional params" in route would make params without ^ prefix optional.
+* Add optional parameters in route. Including "with optional params" in route would make params
+  without ^ prefix optional.
 * Add more test cases, some bug fix in app.js to fully support defaults.
 
 ## May 15, 2012

--- a/modules/app/lib/main.js
+++ b/modules/app/lib/main.js
@@ -60,6 +60,7 @@ exports.exec = function() {
         option('-r, --routes <routes>', 'path of dir containing routes', cwd + '/routes').
         option('-x, --xformers <xformers>', 'path of dir containing xformers', cwd + '/config/xformers.json').
         option('-a, --ecvPath <ecvPath>', 'ecv path', '/ecv').
+        option('-c, --ecvControl <ecvControl>', 'allow disabling ecv', false).
         option('-n, --noWorkers <noWorkers>', 'no of workers', os.cpus.length).
         option('-e, --disableConsole', 'disable the console', false).
         option('-q, --disableQ', 'disable /q', false);
@@ -84,10 +85,11 @@ exports.exec = function() {
         disableConsole: program.disableConsole,
         disableQ: program.disableQ,
         noWorkers: program.noWorkers,
-        ecvPath: program.ecvPath,
         'request-id': program.requestId || 'Request-ID',
         loggerFn: loggerFn,
         ecv: {
+            path: program.ecvPath,
+            control: program.ecvControl,
             monitor: '/tables',
             validator: function(status, headers, data) {
                 return JSON.parse(data);

--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-app",
-    "version": "0.5.4",
+    "version": "0.5.5",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"


### PR DESCRIPTION
See "Routing Traffic" section on http://ql-io.github.com/cluster2/.
