### PR TITLE
Fix regressions 

### DIFF
--- a/modules/app/package.json
+++ b/modules/app/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-app",
-    "version": "0.6.7",
+    "version": "0.6.8",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"
@@ -15,8 +15,8 @@
     },
     "dependencies": {
         "commander": "0.6.0",
-        "ql.io-console": "0.6.7",
-        "ql.io-compiler": "0.6.4",
+        "ql.io-console": "0.6.8",
+        "ql.io-compiler": "0.6.5",
         "winston": "0.5.11",
         "express": "2.5.9",
         "underscore": "1.3.3",

--- a/modules/compiler/lib/compiler.js
+++ b/modules/compiler/lib/compiler.js
@@ -128,7 +128,6 @@ function plan(compiled) {
     // Reverse links from dependencies and pickup orphans
     var used = [];
     function rev(node) {
-        // used.push(node.id);
         _.each(node.dependsOn, function(dependency) {
             used.push(dependency.id);
             rev(dependency);

--- a/modules/compiler/package.json
+++ b/modules/compiler/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-compiler",
-    "version": "0.6.4",
+    "version": "0.6.5",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"

--- a/modules/compiler/test/arr-test.js
+++ b/modules/compiler/test/arr-test.js
@@ -27,9 +27,9 @@ exports['simple'] = function(test) {
     test.equals(compiled.type, 'return');
     test.equals(compiled.comments[0].text, 'Return now');
     test.equals(compiled.rhs.ref, 'n');
-    test.deepEqual(compiled.dependsOn[0].object,
+    test.deepEqual(compiled.rhs.dependsOn[0].object,
         [['Gap', 'Addidas', 'Gravati2a'], ['Gap', 'Addidasf'], ['Gravati', 'Addis']]);
-    test.equals(compiled.dependsOn[0].type, 'define');
-    test.equals(compiled.dependsOn[0].assign, 'n');
+    test.equals(compiled.rhs.dependsOn[0].type, 'define');
+    test.equals(compiled.rhs.dependsOn[0].assign, 'n');
     test.done();
 };

--- a/modules/compiler/test/create-test.js
+++ b/modules/compiler/test/create-test.js
@@ -21,9 +21,9 @@ var compiler = require('../lib/compiler');
 exports['simple'] = function(test) {
     var q = "create table twitter.public on select get from 'http://twitter.com/statuses/public_timeline.{^format}'  using defaults format = 'json'";
     var compiled = compiler.compile(q);
-    test.equal(compiled.dependsOn[0].type, 'create');
-    test.equal(compiled.dependsOn[0].name, 'twitter.public');
-    test.deepEqual(compiled.dependsOn[0].select, { method: 'get',
+    test.equal(compiled.rhs.dependsOn[0].type, 'create');
+    test.equal(compiled.rhs.dependsOn[0].name, 'twitter.public');
+    test.deepEqual(compiled.rhs.dependsOn[0].select, { method: 'get',
                     uri: 'http://twitter.com/statuses/public_timeline.{^format}',
                     defaults: { format: 'json' },
                     aliases: {},
@@ -45,8 +45,8 @@ exports['multiple actions'] = function(test) {
             using patch "shorten.js"\
             resultset "data.expand"';
     var compiled = compiler.compile(q);
-    test.deepEqual(compiled.dependsOn[0].name, 'bitly.shorten');
-    test.deepEqual(compiled.dependsOn[0].insert, { method: 'get',
+    test.deepEqual(compiled.rhs.dependsOn[0].name, 'bitly.shorten');
+    test.deepEqual(compiled.rhs.dependsOn[0].insert, { method: 'get',
                     uri: 'http://api.bitly.com/v3/shorten?login={^login}&apiKey={^apikey}&longUrl={^longUrl}&format={format}',
                     defaults:
                     { apikey: '{config.tables.bitly.shorten.apikey}',
@@ -58,7 +58,7 @@ exports['multiple actions'] = function(test) {
                     cache: {},
                     patch: 'shorten.js',
                     body: '' });
-    test.deepEqual(compiled.dependsOn[0].select, { method: 'get',
+    test.deepEqual(compiled.rhs.dependsOn[0].select, { method: 'get',
                     uri: 'http://api.bitly.com/v3/expand?login={^login}&apiKey={^apikey}&shortUrl={^shortUrl}&format={format}',
                     defaults:
                     { apikey: '{config.tables.bitly.shorten.apikey}',
@@ -94,7 +94,7 @@ create table ebay.trading.getmyebaybuying\
     using patch "getmyebaybuying.js"\
     using bodyTemplate "getmyebaybuying.xml.mu" type "application/xml"';
     var compiled = compiler.compile(script);
-    test.equals(compiled.dependsOn[0].select.body.type, 'application/xml');
+    test.equals(compiled.rhs.dependsOn[0].select.body.type, 'application/xml');
     test.done();
 };
 
@@ -121,7 +121,7 @@ create table ebay.trading.getmyebaybuying\n\
 
     try {
         var compiled = compiler.compile(script);
-        test.equals(compiled.dependsOn[0].select.body.type, 'application/xml;foo=bar');
+        test.equals(compiled.rhs.dependsOn[0].select.body.type, 'application/xml;foo=bar');
         test.done();
     }
     catch(e) {
@@ -152,7 +152,7 @@ create table ebay.trading.getmyebaybuying\n\
 
     try {
         var compiled = compiler.compile(script);
-        test.equals(compiled.dependsOn[0].select.body.type, 'application/x-www-form-urlencoded');
+        test.equals(compiled.rhs.dependsOn[0].select.body.type, 'application/x-www-form-urlencoded');
         test.done();
     }
     catch(e) {
@@ -164,7 +164,7 @@ exports['auth'] = function(test) {
     var script = 'create table ebay.finding.items on select get from "{config.tables.ebay.finding.items.url}" authenticate using "authmod"';
     try {
         var compiled = compiler.compile(script);
-        test.equals(compiled.dependsOn[0].select.auth, 'authmod');
+        test.equals(compiled.rhs.dependsOn[0].select.auth, 'authmod');
         test.done();
     }
     catch(e) {
@@ -177,7 +177,7 @@ exports['create-many'] = function(test) {
                   create table two on select post to "url2"';
     var compiled = compiler.compile(script);
 
-    test.deepEqual(compiled.dependsOn[0].select, { method: 'get',
+    test.deepEqual(compiled.rhs.dependsOn[0].select, { method: 'get',
                 uri: 'url1',
                 defaults: {},
                 aliases: {},
@@ -186,7 +186,7 @@ exports['create-many'] = function(test) {
                 cache: {},
                 body: '' });
 
-    test.deepEqual(compiled.dependsOn[1].select, { method: 'post',
+    test.deepEqual(compiled.rhs.dependsOn[1].select, { method: 'post',
                 uri: 'url2',
                 defaults: {},
                 aliases: {},
@@ -203,9 +203,9 @@ exports['create-deps'] = function(test) {
                   resp = select * from mytable;\n\
                   return '{resp.$..item}'";
     var plan = compiler.compile(script);
-    test.equals(plan.dependsOn.length, 1);
-    test.equals(plan.dependsOn[0].type, 'select');
-    test.equals(plan.dependsOn[0].dependsOn.length, 1);
-    test.equals(plan.dependsOn[0].dependsOn[0].type, 'create');
+    test.equals(plan.rhs.dependsOn.length, 1);
+    test.equals(plan.rhs.dependsOn[0].type, 'select');
+    test.equals(plan.rhs.dependsOn[0].dependsOn.length, 1);
+    test.equals(plan.rhs.dependsOn[0].dependsOn[0].type, 'create');
     test.done();
 }

--- a/modules/compiler/test/delete-test.js
+++ b/modules/compiler/test/delete-test.js
@@ -21,71 +21,58 @@ var compiler = require('../lib/compiler');
 exports['delete'] = function (test) {
     var q = "delete from foo where bar = 'a'";
     var plan = compiler.compile(q);
-    var e = {
-        "type": "delete",
-        "source": {
-            "name": "foo"
-        },
-        "whereCriteria": [{
+    test.equals(plan.rhs.type, 'delete');
+    test.equals(plan.rhs.source.name, 'foo');
+    test.deepEqual(plan.rhs.whereCriteria, [
+        {
             "operator": "=",
             "lhs": {name: "bar", type: 'column'},
             "rhs": {
                 "value": "a"
             }
-        }],
-        "line": 1,
-        "id": 0
-    };
-    test.deepEqual(plan.rhs, e);
+        }
+    ]);
     test.done();
 };
 
 exports['delete-csv'] = function (test) {
     var q = "delete from ebay.item where itemId in ('180652013910','120711247507')";
     var plan = compiler.compile(q);
-    var e = {
-        type: 'delete',
-        "source" :
-            {name: 'ebay.item'},
-        whereCriteria: [{
+    test.equals(plan.rhs.type, 'delete');
+    test.equals(plan.rhs.source.name, 'ebay.item');
+    test.deepEqual(plan.rhs.whereCriteria, [
+        {
             operator: 'in',
             lhs: {name: 'itemId'},
-            "rhs":{
+            "rhs": {
                 value: ['180652013910', '120711247507']
             }
-        }],
-        line: 1,
-        id: 0
-    };
-    test.deepEqual(plan.rhs, e);
+        }
+    ]);
     test.done();
 };
 
-exports['delete-timeouts'] = function(test) {
+exports['delete-timeouts'] = function (test) {
     var q = "delete from ebay.item where itemId in ('180652013910','120711247507') timeout 10 minDelay 100 maxDelay 10000";
     var plan = compiler.compile(q);
-    var e = {
-            type: 'delete',
-            "source" :
-                {name: 'ebay.item'},
-            whereCriteria: [{
-                operator: 'in',
-                lhs: {name: 'itemId'},
-                "rhs":{
-                    value: ['180652013910', '120711247507']
-                }
-            }],
-            timeout: 10,
-            minDelay: 100,
-            maxDelay: 10000,
-            line: 1,
-            id: 0
-        };
-    test.deepEqual(plan.rhs, e);
+    test.equals(plan.rhs.type, 'delete');
+    test.equals(plan.rhs.source.name, 'ebay.item');
+    test.deepEqual(plan.rhs.whereCriteria, [
+        {
+            operator: 'in',
+            lhs: {name: 'itemId'},
+            "rhs": {
+                value: ['180652013910', '120711247507']
+            }
+        }
+    ]);
+    test.equal(plan.rhs.timeout, 10);
+    test.equal(plan.rhs.minDelay, 100);
+    test.equal(plan.rhs.maxDelay, 10000);
     test.done();
 };
 
-exports['delete-from-obj'] = function(test) {
+exports['delete-from-obj'] = function (test) {
     var q = 'obj = {\
                 "a" : "A",\
                 "b" : "B",\
@@ -100,7 +87,7 @@ exports['delete-from-obj'] = function(test) {
                 lhs: { type: 'column', name: 'a' },
                 rhs: { value: 'A' } }
         ]);
-    test.deepEqual(plan.dependsOn[0].object, { a: 'A', b: 'B', c: 'C' });
+    test.deepEqual(plan.rhs.dependsOn[0].object, { a: 'A', b: 'B', c: 'C' });
     test.done();
 }
 

--- a/modules/compiler/test/dependency-test.js
+++ b/modules/compiler/test/dependency-test.js
@@ -27,12 +27,12 @@ module.exports = {
                   c = "{b}";\
                   return c;'
         plan = compiler.compile(script);
-        test.equals(plan.dependsOn.length, 1);
-        test.equals(plan.dependsOn[0].object, '{b}');
-        test.equals(plan.dependsOn[0].dependsOn.length, 1);
-        test.equals(plan.dependsOn[0].dependsOn[0].object, '{a}');
-        test.equals(plan.dependsOn[0].dependsOn[0].dependsOn.length, 1);
-        test.equals(plan.dependsOn[0].dependsOn[0].dependsOn[0].object, 'a');
+        test.equals(plan.rhs.dependsOn.length, 1);
+        test.equals(plan.rhs.dependsOn[0].object, '{b}');
+        test.equals(plan.rhs.dependsOn[0].dependsOn.length, 1);
+        test.equals(plan.rhs.dependsOn[0].dependsOn[0].object, '{a}');
+        test.equals(plan.rhs.dependsOn[0].dependsOn[0].dependsOn.length, 1);
+        test.equals(plan.rhs.dependsOn[0].dependsOn[0].dependsOn[0].object, 'a');
         test.done();
     },
 

--- a/modules/compiler/test/describe-test.js
+++ b/modules/compiler/test/describe-test.js
@@ -21,26 +21,16 @@ var compiler = require('../lib/compiler');
 exports['describe'] = function (test) {
     var q = "describe foo";
     var statement = compiler.compile(q);
-    var e = {
-        type: 'describe',
-        line: 1,
-        source: {'name': 'foo' },
-        id: 0
-    };
-    test.deepEqual(statement.rhs, e);
+    test.equals(statement.rhs.type, 'describe');
+    test.equals(statement.rhs.source.name, 'foo');
     test.done();
 };
 
 exports['desc'] = function (test) {
     var q = "desc foo";
     var statement = compiler.compile(q);
-    var e = {
-        type: 'describe',
-        line: 1,
-        source: {'name': 'foo' },
-        id: 0
-    };
-    test.deepEqual(statement.rhs, e);
+    test.equals(statement.rhs.type, 'describe');
+    test.equals(statement.rhs.source.name, 'foo');
     test.done();
 };
 
@@ -60,7 +50,7 @@ exports['describe-no-table'] = function(test) {
 exports['describe-assign'] = function (test) {
     var q = "des = describe foo; return {};";
     var statement = compiler.compile(q);
-    test.equal(statement.dependsOn[0].assign, 'des');
+    test.equal(statement.rhs.dependsOn[0].assign, 'des');
     test.done();
 };
 

--- a/modules/compiler/test/fallback-test.js
+++ b/modules/compiler/test/fallback-test.js
@@ -78,16 +78,16 @@ module.exports = {
                  return foo;";
         var statement = compiler.compile(q);
         test.equal(statement.rhs.ref, 'foo')
-        test.equal(statement.dependsOn.length, 1)
-        test.equal(statement.dependsOn[0].type, 'select');
-        test.equal(statement.dependsOn[0].fromClause[0].name, '{a}');
-        test.equal(statement.dependsOn[0].dependsOn.length, 1);
-        test.equal(statement.dependsOn[0].dependsOn[0].fromClause[0].name, 'A');
-        test.equal(statement.dependsOn[0].fallback.type, 'select');
-        test.equal(statement.dependsOn[0].fallback.fromClause[0].name, '{b}');
-        test.equal(statement.dependsOn[0].fallback.dependsOn.length, 1);
-        test.equal(statement.dependsOn[0].fallback.dependsOn[0].fromClause[0].name, 'B');
-        test.equal(statement.rhs.ref, statement.dependsOn[0].fallback.assign)
+        test.equal(statement.rhs.dependsOn.length, 1)
+        test.equal(statement.rhs.dependsOn[0].type, 'select');
+        test.equal(statement.rhs.dependsOn[0].fromClause[0].name, '{a}');
+        test.equal(statement.rhs.dependsOn[0].dependsOn.length, 1);
+        test.equal(statement.rhs.dependsOn[0].dependsOn[0].fromClause[0].name, 'A');
+        test.equal(statement.rhs.dependsOn[0].fallback.type, 'select');
+        test.equal(statement.rhs.dependsOn[0].fallback.fromClause[0].name, '{b}');
+        test.equal(statement.rhs.dependsOn[0].fallback.dependsOn.length, 1);
+        test.equal(statement.rhs.dependsOn[0].fallback.dependsOn[0].fromClause[0].name, 'B');
+        test.equal(statement.rhs.ref, statement.rhs.dependsOn[0].fallback.assign)
         test.done();
     },
 
@@ -119,9 +119,9 @@ module.exports = {
         test.equals(plan.rhs.fallback.dependsOn[0].dependsOn.length, 1);
         test.equals(plan.rhs.fallback.dependsOn[0].dependsOn[0].type, 'define');
         test.equals(plan.rhs.fallback.dependsOn[0].dependsOn[0].assign, 'data');
-        test.equals(plan.dependsOn.length, 1);
-        test.equals(plan.dependsOn[0].type, 'select');
-        test.equals(plan.dependsOn[0].assign, 'b');
+        test.equals(plan.rhs.dependsOn.length, 1);
+        test.equals(plan.rhs.dependsOn[0].type, 'select');
+        test.equals(plan.rhs.dependsOn[0].assign, 'b');
         test.equals(plan.rhs.fallback.dependsOn.length, 1);
         test.equals(plan.rhs.fallback.dependsOn[0].type, 'select');
         test.equals(plan.rhs.fallback.dependsOn[0].assign, 'a');

--- a/modules/compiler/test/line-prerequisite-test.js
+++ b/modules/compiler/test/line-prerequisite-test.js
@@ -55,10 +55,10 @@ exports['Multi-line Two level select with where = & in '] = function(test) {
         var5 = select * from abcd where id in (select * from pqr where id = "{^var6}");\
         return {"var3":"{var3}","var5":"{var5}"};';
     var compiled = compiler.compile(q);
-    test.equal(compiled.dependsOn[0].preRequisites.length, 1);
-    test.equal(compiled.dependsOn[0].preRequisites[0], 'var4');
-    test.equal(compiled.dependsOn[1].preRequisites.length, 1);
-    test.equal(compiled.dependsOn[1].preRequisites[0], 'var6');
+    test.equal(compiled.rhs.dependsOn[0].preRequisites.length, 1);
+    test.equal(compiled.rhs.dependsOn[0].preRequisites[0], 'var4');
+    test.equal(compiled.rhs.dependsOn[1].preRequisites.length, 1);
+    test.equal(compiled.rhs.dependsOn[1].preRequisites[0], 'var6');
     test.done();
 };
 

--- a/modules/compiler/test/ql-script-test.js
+++ b/modules/compiler/test/ql-script-test.js
@@ -30,16 +30,16 @@ module.exports = {
         var statement = compiler.compile(q);
         test.equals(statement.type, 'return');
         test.equals(statement.rhs.ref, 'results');
-        test.equals(statement.dependsOn.length, 1);
-        test.equals(statement.dependsOn[0].assign, 'results');
-        test.equals(statement.dependsOn[0].type, 'select');
-        test.equals(statement.dependsOn[0].listeners.length, 1);
-        test.equals(statement.dependsOn[0].listeners[0].type, 'return');
-        test.equals(statement.dependsOn[0].dependsOn.length, 1);
-        test.equals(statement.dependsOn[0].dependsOn[0].assign, 'a');
-        test.equals(statement.dependsOn[0].dependsOn[0].type, 'select');
-        test.equals(statement.dependsOn[0].dependsOn[0].listeners.length, 1);
-        test.equals(statement.dependsOn[0].dependsOn[0].listeners[0].type, 'select');
+        test.equals(statement.rhs.dependsOn.length, 1);
+        test.equals(statement.rhs.dependsOn[0].assign, 'results');
+        test.equals(statement.rhs.dependsOn[0].type, 'select');
+        test.equals(statement.rhs.dependsOn[0].listeners.length, 1);
+        test.equals(statement.rhs.dependsOn[0].listeners[0].type, 'ref');
+        test.equals(statement.rhs.dependsOn[0].dependsOn.length, 1);
+        test.equals(statement.rhs.dependsOn[0].dependsOn[0].assign, 'a');
+        test.equals(statement.rhs.dependsOn[0].dependsOn[0].type, 'select');
+        test.equals(statement.rhs.dependsOn[0].dependsOn[0].listeners.length, 1);
+        test.equals(statement.rhs.dependsOn[0].dependsOn[0].listeners[0].type, 'select');
         test.done();
     },
 
@@ -55,13 +55,13 @@ module.exports = {
         var plan = compiler.compile(script);
         test.equals(plan.type, 'return');
         test.equals(plan.rhs.type, 'define');
-        test.equals(plan.dependsOn[0].assign, 'bidList'); // orphan
-        test.equals(plan.dependsOn[1].assign, 'bestOfferList'); // orphan
-        test.equals(plan.dependsOn[2].assign, 'watches');
-        test.equals(plan.dependsOn[2].dependsOn[0].assign, 'watchList');
-        test.equals(plan.dependsOn[2].dependsOn[0].listeners[0].assign, 'watches');
-        test.equals(plan.dependsOn[2].dependsOn[0].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
-        test.equals(plan.dependsOn[2].dependsOn[0].dependsOn[0].listeners[0].assign, 'watchList');
+        test.equals(plan.rhs.dependsOn[0].assign, 'bidList'); // orphan
+        test.equals(plan.rhs.dependsOn[1].assign, 'bestOfferList'); // orphan
+        test.equals(plan.rhs.dependsOn[2].assign, 'watches');
+        test.equals(plan.rhs.dependsOn[2].dependsOn[0].assign, 'watchList');
+        test.equals(plan.rhs.dependsOn[2].dependsOn[0].listeners[0].assign, 'watches');
+        test.equals(plan.rhs.dependsOn[2].dependsOn[0].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
+        test.equals(plan.rhs.dependsOn[2].dependsOn[0].dependsOn[0].listeners[0].assign, 'watchList');
         test.done();
     },
 
@@ -74,9 +74,9 @@ module.exports = {
                   };'
 
         var plan = compiler.compile(script);
-        test.equals(plan.dependsOn[0].assign, 'itemDetails');
-        test.equals(plan.dependsOn[0].dependsOn[0].assign, 'watchList');
-        test.equals(plan.dependsOn[0].dependsOn[0].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
+        test.equals(plan.rhs.dependsOn[0].assign, 'itemDetails');
+        test.equals(plan.rhs.dependsOn[0].dependsOn[0].assign, 'watchList');
+        test.equals(plan.rhs.dependsOn[0].dependsOn[0].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
         test.done();
     },
 
@@ -89,9 +89,9 @@ module.exports = {
                   };'
 
         var plan = compiler.compile(script);
-        test.equals(plan.dependsOn[0].assign, 'itemDetails');
-        test.equals(plan.dependsOn[0].dependsOn[0].assign, 'watchList');
-        test.equals(plan.dependsOn[0].dependsOn[0].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
+        test.equals(plan.rhs.dependsOn[0].assign, 'itemDetails');
+        test.equals(plan.rhs.dependsOn[0].dependsOn[0].assign, 'watchList');
+        test.equals(plan.rhs.dependsOn[0].dependsOn[0].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
         test.done();
     },
 
@@ -116,17 +116,17 @@ module.exports = {
                   };';
         try {
             var plan = compiler.compile(script);
-            test.equals(plan.dependsOn.length, 2);
-            test.equals(plan.dependsOn[0].assign, 'watches');
-            test.equals(plan.dependsOn[1].dependsOn.length, 4);
-            test.equals(plan.dependsOn[1].dependsOn[0].assign, 'watchList');
-            test.equals(plan.dependsOn[1].dependsOn[0].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
-            test.equals(plan.dependsOn[1].dependsOn[1].assign, 'bidList');
-            test.equals(plan.dependsOn[1].dependsOn[1].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
-            test.equals(plan.dependsOn[1].dependsOn[2].assign, 'bestOfferList');
-            test.equals(plan.dependsOn[1].dependsOn[2].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
-            test.equals(plan.dependsOn[1].dependsOn[3].assign, 'activeList');
-            test.equals(plan.dependsOn[1].dependsOn[3].dependsOn[0].assign, 'GetMyeBaySellingResponse');
+            test.equals(plan.rhs.dependsOn.length, 2);
+            test.equals(plan.rhs.dependsOn[0].assign, 'watches');
+            test.equals(plan.rhs.dependsOn[1].dependsOn.length, 4);
+            test.equals(plan.rhs.dependsOn[1].dependsOn[0].assign, 'watchList');
+            test.equals(plan.rhs.dependsOn[1].dependsOn[0].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
+            test.equals(plan.rhs.dependsOn[1].dependsOn[1].assign, 'bidList');
+            test.equals(plan.rhs.dependsOn[1].dependsOn[1].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
+            test.equals(plan.rhs.dependsOn[1].dependsOn[2].assign, 'bestOfferList');
+            test.equals(plan.rhs.dependsOn[1].dependsOn[2].dependsOn[0].assign, 'GetMyeBayBuyingResponse');
+            test.equals(plan.rhs.dependsOn[1].dependsOn[3].assign, 'activeList');
+            test.equals(plan.rhs.dependsOn[1].dependsOn[3].dependsOn[0].assign, 'GetMyeBaySellingResponse');
             test.done();
         }
         catch(e) {
@@ -145,10 +145,10 @@ module.exports = {
                   };'
         try {
             var plan = compiler.compile(script);
-            test.equals(plan.dependsOn.length, 1);
-            test.equals(plan.dependsOn[0].type, 'select');
-            test.equals(plan.dependsOn[0].dependsOn.length, 1);
-            test.equals(plan.dependsOn[0].dependsOn[0].type, 'select');
+            test.equals(plan.rhs.dependsOn.length, 1);
+            test.equals(plan.rhs.dependsOn[0].type, 'select');
+            test.equals(plan.rhs.dependsOn[0].dependsOn.length, 1);
+            test.equals(plan.rhs.dependsOn[0].dependsOn[0].type, 'select');
             test.done();
         }
         catch(e) {
@@ -180,10 +180,10 @@ return {"result" : "{fields}"};\
         try {
             var plan = compiler.compile(script);
             test.equals(plan.type, 'return');
-            test.equals(plan.dependsOn.length, 1);
-            test.equals(plan.dependsOn[0].type, 'select')
-            test.equals(plan.dependsOn[0].dependsOn.length, 1);
-            test.equals(plan.dependsOn[0].dependsOn[0].type, 'define');
+            test.equals(plan.rhs.dependsOn.length, 1);
+            test.equals(plan.rhs.dependsOn[0].type, 'select')
+            test.equals(plan.rhs.dependsOn[0].dependsOn.length, 1);
+            test.equals(plan.rhs.dependsOn[0].dependsOn[0].type, 'define');
             test.done();
         }
         catch(e) {
@@ -331,6 +331,18 @@ return {"result" : "{fields}"};\
         test.equal(plan.comments[0].text, 'line comment');
         test.equal(plan.comments[1].text, 'block comment\n        block\n        ');
         test.equal(plan.comments[2].text, 'another block ');
+        test.done();
+    },
+
+    'var-subst-orphans': function(test) {
+        var script = 'var1 = "hello";var2 = "{var1.prop}"; var3 = "{var2.prop}"; return {};';
+        var plan = compiler.compile(script);
+        test.equals(plan.rhs.dependsOn.length, 1);
+        test.equals(plan.rhs.dependsOn[0].assign, 'var3');
+        test.equals(plan.rhs.dependsOn[0].dependsOn.length, 1);
+        test.equals(plan.rhs.dependsOn[0].dependsOn[0].assign, 'var2');
+        test.equals(plan.rhs.dependsOn[0].dependsOn[0].dependsOn.length, 1);
+        test.equals(plan.rhs.dependsOn[0].dependsOn[0].dependsOn[0].assign, 'var1');
         test.done();
     }
 };

--- a/modules/compiler/test/route-test.js
+++ b/modules/compiler/test/route-test.js
@@ -22,7 +22,7 @@ exports['route get'] = function (test) {
     var q = "des = describe foo; return des via route '/foo/bar' using method get;";
     var compiled = compiler.compile(q);
     test.equals(compiled.type, 'return', 'expected return');
-    test.equals(compiled.dependsOn[0].type, 'describe', 'expected describe');
+    test.equals(compiled.rhs.dependsOn[0].type, 'describe', 'expected describe');
     test.ok(compiled.route, 'expected a route');
     test.ok(compiled.route.path.value, '/foo/bar');
     test.ok(compiled.route.method, 'get');
@@ -34,7 +34,7 @@ exports['route post'] = function (test) {
     var q = "des = describe foo; return des via route '/foo/{id}' using method post;";
     var compiled = compiler.compile(q);
     test.equals(compiled.type, 'return', 'expected return');
-    test.equals(compiled.dependsOn[0].type, 'describe', 'expected describe');
+    test.equals(compiled.rhs.dependsOn[0].type, 'describe', 'expected describe');
     test.ok(compiled.route, 'expected a route');
     test.ok(compiled.route.path.value, '/foo/bar');
     test.ok(compiled.route.method, 'get');

--- a/modules/compiler/test/route-using-headers-test.js
+++ b/modules/compiler/test/route-using-headers-test.js
@@ -29,17 +29,6 @@ exports['route using header'] = function (test) {
     test.done();
 };
 
-exports['route using headers'] = function (test) {
-    var q = "return {} via route '/foo/bar' using method get using headers 'A' = 'B', 'B' = 'C';";
-    var compiled = compiler.compile(q);
-    test.equals(compiled.type, 'return', 'expected return');
-    test.ok(compiled.route, 'expected a route');
-    test.ok(compiled.route.path.value, '/foo/bar');
-    test.ok(compiled.route.method, 'get');
-    test.deepEqual(compiled.route.headers, {'A' : 'B', 'B' : 'C'});
-    test.done();
-};
-
 exports['route using headers token name'] = function (test) {
     var q = "name = \"hello\";return {} via route '/foo/bar' using method get using headers '{name}' = 'B', 'B' = 'C';";
     var compiled = compiler.compile(q);

--- a/modules/compiler/test/select-test.js
+++ b/modules/compiler/test/select-test.js
@@ -22,17 +22,7 @@ module.exports = {
     'select-star': function(test) {
         var q = "select * from foo";
         var statement = compiler.compile(q);
-        var e = {
-                type: 'select',
-                fromClause: [
-                    {'name': 'foo' }
-                ],
-                columns: {name: '*', type: 'column'},
-                whereCriteria: undefined,
-                id: 0,
-                line: 1
-            };
-        test.deepEqual(statement.rhs, e);
+        test.deepEqual(statement.rhs.columns, {name: '*', type: 'column'});
         test.done();
     },
 
@@ -40,22 +30,12 @@ module.exports = {
         var q = 'select title[0], itemId[0], primaryCategory[0].categoryName[0], ' +
             'sellingStatus[0].currentPrice[0] from ebay.finding.items';
         var statement = compiler.compile(q);
-        var e = {
-                type: 'select',
-                fromClause: [
-                    {'name': 'ebay.finding.items' }
-                ],
-                columns: [
-                    {name: 'title[0]', type: "column"},
-                    {name: 'itemId[0]', type: "column"},
-                    {name: 'primaryCategory[0].categoryName[0]', type: "column"},
-                    {name: 'sellingStatus[0].currentPrice[0]', type: "column"}
-                ],
-                whereCriteria: undefined,
-                id: 0,
-                line: 1
-            };
-        test.deepEqual(statement.rhs, e);
+        test.deepEqual(statement.rhs.columns, [
+            {name: 'title[0]', type: "column"},
+            {name: 'itemId[0]', type: "column"},
+            {name: 'primaryCategory[0].categoryName[0]', type: "column"},
+            {name: 'sellingStatus[0].currentPrice[0]', type: "column"}
+        ]);
         test.done();
     },
 
@@ -63,26 +43,17 @@ module.exports = {
         var q = 'select title[0], itemId[0], primaryCategory[0].categoryName[0], ' +
             'sellingStatus[0].currentPrice[0] from ebay.finding.items where keywords="cooper"';
         var statement = compiler.compile(q);
-        var e = {
-                type: 'select',
-                line: 1,
-                fromClause: [
-                    {name: 'ebay.finding.items' }
-                ],
-                columns: [
-                    {name: 'title[0]', type: "column"},
-                    {name: 'itemId[0]', type: "column"},
-                    {name: 'primaryCategory[0].categoryName[0]', type: "column"},
-                    {name: 'sellingStatus[0].currentPrice[0]', type: "column"}
-                ],
-                whereCriteria: [
-                    { operator: '=', lhs: {name: 'keywords', type: "column"}, rhs: {
-                        value: 'cooper'
-                    } }
-                ],
-                id: 0
-            };
-        test.deepEqual(statement.rhs, e);
+        test.deepEqual(statement.rhs.columns, [
+            {name: 'title[0]', type: "column"},
+            {name: 'itemId[0]', type: "column"},
+            {name: 'primaryCategory[0].categoryName[0]', type: "column"},
+            {name: 'sellingStatus[0].currentPrice[0]', type: "column"}
+        ]);
+        test.deepEqual(statement.rhs.whereCriteria, [
+            { operator: '=', lhs: {name: 'keywords', type: "column"}, rhs: {
+                value: 'cooper'
+            } }
+        ]);
         test.done();
     },
 
@@ -90,50 +61,27 @@ module.exports = {
         var q = 'select e.title[0], e.itemId[0], e.primaryCategory[0].categoryName[0], ' +
             'e.sellingStatus[0].currentPrice[0] from ebay.finding.items as e where keywords="cooper"';
         var statement = compiler.compile(q);
-        var e = {
-                type: 'select',
-                line: 1,
-                fromClause: [
-                    {name: 'ebay.finding.items', alias: 'e' }
-                ],
-                columns: [
-                    {name: 'e.title[0]', type: "column"},
-                    {name: 'e.itemId[0]', type: "column"},
-                    {name: 'e.primaryCategory[0].categoryName[0]', type: "column"},
-                    {name: 'e.sellingStatus[0].currentPrice[0]', type: "column"}
-                ],
-                whereCriteria: [
-                    { operator: '=', lhs: {type: "column", name: 'keywords'}, rhs: {
-                        value: 'cooper'
-                    } }
-                ],
-                id: 0
-            };
-        test.deepEqual(statement.rhs, e);
+        test.deepEqual(statement.rhs.fromClause, [
+            {name: 'ebay.finding.items', alias: 'e' }
+        ]);
         test.done();
     },
 
     'select-in-csv': function(test) {
         var q = "select ViewItemURLForNaturalSearch from ebay.item where itemId in ('180652013910','120711247507')";
         var statement = compiler.compile(q);
-        var e = {
-                type: 'select',
-                line: 1,
-                fromClause: [
+        test.deepEqual(statement.rhs.fromClause, [
                     {name: 'ebay.item'}
-                ],
-                columns: [
-                    {name: 'ViewItemURLForNaturalSearch', type: "column"}
-                ],
-                whereCriteria: [
-                    { operator: 'in', lhs: {name: 'itemId'}, "rhs":{
-                        value: ['180652013910', '120711247507']
-                    }
-                    }
-                ],
-                id: 0
-            };
-        test.deepEqual(statement.rhs, e);
+                ]);
+        test.deepEqual(statement.rhs.columns, [
+            {name: 'ViewItemURLForNaturalSearch', type: "column"}
+        ]);
+        test.deepEqual(statement.rhs.whereCriteria, [
+            { operator: 'in', lhs: {name: 'itemId'}, "rhs": {
+                value: ['180652013910', '120711247507']
+            }
+            }
+        ]);
         test.done();
     },
 
@@ -181,59 +129,55 @@ module.exports = {
         var q = "select e.Title, e.ItemID, g.geometry.location from ebay.item as e, google.geocode as g where e.itemId in \
             (select itemId from ebay.finding.items where keywords = 'mini') and g.address = e.Location"
         var statement = compiler.compile(q);
-        var e = {
-                "type": "select",
-                "line": 1,
-                "columns": [
-                    { type: 'column', name: 'e.Title' },
-                    { type: 'column', name: 'e.ItemID' },
-                    { type: 'column', name: 'e.Location' }
-                ],
-                selected: [
-                    { from: 'main', index: 0 },
-                    { from: 'main', index: 1 },
-                    { from: 'joiner', index: 0 }
-                ],
-                extras: [ 2 ],
-                whereCriteria: [
-                    { operator: 'in',
-                        lhs: { name: 'e.itemId' },
-                        rhs: { type: 'select',
-                            line: 1,
-                            fromClause: [
-                                { name: 'ebay.finding.items' }
-                            ],
-                            columns: [
-                                { type: 'column', name: 'itemId' }
-                            ],
-                            whereCriteria: [
-                                { operator: '=',
-                                    lhs: { type: 'column', name: 'keywords' },
-                                    rhs: { value: 'mini' } }
-                            ],
-                            dependsOn: [] } }
-                ],
-                fromClause: [
-                    { name: 'ebay.item', alias: 'e' }
-                ],
-                joiner: { type: 'select',
+        test.deepEqual(statement.rhs.columns, [
+            { type: 'column', name: 'e.Title' },
+            { type: 'column', name: 'e.ItemID' },
+            { type: 'column', name: 'e.Location' }
+        ]);
+        test.deepEqual(statement.rhs.selected, [
+            { from: 'main', index: 0 },
+            { from: 'main', index: 1 },
+            { from: 'joiner', index: 0 }
+        ]);
+
+        test.deepEqual(statement.rhs.extras, [ 2 ]);
+        test.deepEqual(statement.rhs.whereCriteria, [
+            { operator: 'in',
+                lhs: { name: 'e.itemId' },
+                rhs: { type: 'select',
                     line: 1,
-                    columns: [
-                        { type: 'column', name: 'g.geometry.location' },
-                        { type: 'column', name: 'g.address' }
+                    fromClause: [
+                        { name: 'ebay.finding.items' }
                     ],
-                    extras: [ 1 ],
+                    columns: [
+                        { type: 'column', name: 'itemId' }
+                    ],
                     whereCriteria: [
                         { operator: '=',
-                            lhs: { type: 'column', name: 'g.address' },
-                            rhs: { type: 'alias', value: 'e.Location', joiningColumn: 2 } }
+                            lhs: { type: 'column', name: 'keywords' },
+                            rhs: { value: 'mini' } }
                     ],
-                    fromClause: [
-                        { name: 'google.geocode', alias: 'g' }
-                    ],
-                    dependsOn: [] },
-                id: 0 };
-        test.deepEqual(statement.rhs, e);
+                    dependsOn: [] } }
+        ]);
+        test.deepEqual(statement.rhs.fromClause, [
+            { name: 'ebay.item', alias: 'e' }
+        ]);
+        test.deepEqual(statement.rhs.joiner, { type: 'select',
+            line: 1,
+            columns: [
+                { type: 'column', name: 'g.geometry.location' },
+                { type: 'column', name: 'g.address' }
+            ],
+            extras: [ 1 ],
+            whereCriteria: [
+                { operator: '=',
+                    lhs: { type: 'column', name: 'g.address' },
+                    rhs: { type: 'alias', value: 'e.Location', joiningColumn: 2 } }
+            ],
+            fromClause: [
+                { name: 'google.geocode', alias: 'g' }
+            ],
+            dependsOn: [] });
         test.done();
     },
 
@@ -241,23 +185,15 @@ module.exports = {
         var q = 'select title[0], itemId[0], primaryCategory[0].categoryName[0], ' +
             'sellingStatus[0].currentPrice[0] from ebay.finding.items limit 4';
         var statement = compiler.compile(q);
-        var e = {
-                type: 'select',
-                line: 1,
-                fromClause: [
-                    {'name': 'ebay.finding.items' }
-                ],
-                columns: [
-                    {name: 'title[0]', type: "column"},
-                    {name: 'itemId[0]', type: "column"},
-                    {name: 'primaryCategory[0].categoryName[0]', type: "column"},
-                    {name: 'sellingStatus[0].currentPrice[0]', type: "column"}
-                ],
-                whereCriteria: undefined,
-                limit: 4,
-                id: 0
-            };
-        test.deepEqual(statement.rhs, e);
+        test.equals(statement.rhs.type, 'select');
+        test.deepEqual(statement.rhs.fromClause, [{'name': 'ebay.finding.items' }]);
+        test.deepEqual(statement.rhs.columns, [
+            {name: 'title[0]', type: "column"},
+            {name: 'itemId[0]', type: "column"},
+            {name: 'primaryCategory[0].categoryName[0]', type: "column"},
+            {name: 'sellingStatus[0].currentPrice[0]', type: "column"}
+        ]);
+        test.equal(statement.rhs.limit, 4);
         test.done();
     },
 
@@ -265,54 +201,29 @@ module.exports = {
         var q = 'select title[0], itemId[0], primaryCategory[0].categoryName[0], ' +
             'sellingStatus[0].currentPrice[0] from ebay.finding.items limit 4 offset 2';
         var statement = compiler.compile(q);
-        var e = {
-                type: 'select',
-                line: 1,
-                fromClause: [
-                    {'name': 'ebay.finding.items' }
-                ],
-                columns: [
-                    {name: 'title[0]', type: "column"},
-                    {name: 'itemId[0]', type: "column"},
-                    {name: 'primaryCategory[0].categoryName[0]', type: "column"},
-                    {name: 'sellingStatus[0].currentPrice[0]', type: "column"}
-                ],
-                whereCriteria: undefined,
-                limit: 4,
-                offset: 2,
-                id: 0
-            };
-        test.deepEqual(statement.rhs, e);
+        test.equals(statement.rhs.type, 'select');
+        test.deepEqual(statement.rhs.fromClause, [{'name': 'ebay.finding.items' }]);
+        test.deepEqual(statement.rhs.columns, [
+            {name: 'title[0]', type: "column"},
+            {name: 'itemId[0]', type: "column"},
+            {name: 'primaryCategory[0].categoryName[0]', type: "column"},
+            {name: 'sellingStatus[0].currentPrice[0]', type: "column"}
+        ]);
+        test.equal(statement.rhs.limit, 4);
+        test.equal(statement.rhs.offset, 2);
         test.done();
     },
 
     'udf': function(test) {
         var q = 'u = require("u");select * from ebay.finditems where u.contains("mini cooper") and u.blendBy()';
         var statement = compiler.compile(q);
-        var e = {
-                "type": "select",
-                "line": 1,
-                "fromClause": [
-                    {
-                        "name": "ebay.finditems"
-                    }
-                ],
-                "columns": {name: "*", type: 'column'},
-                "whereCriteria": [
-                    {
-                        "operator": "udf",
-                        "name": "u.contains",
-                        "args": [{ "type" : "literal", "value": "mini cooper"}]
-                    },
-                    {
-                        "operator": "udf",
-                        "name": "u.blendBy",
-                        "args": ""
-                    }
-                ],
-                id: 1
-            };
-        test.deepEqual(statement.rhs, e);
+        test.equals(statement.rhs.type, 'select');
+        test.deepEqual(statement.rhs.whereCriteria, [ { operator: 'udf',
+            name: 'u.contains',
+            args: [ { type: 'literal', value: 'mini cooper' } ] },
+          { operator: 'udf', name: 'u.blendBy', args: '' } ]);
+        test.equal(statement.rhs.dependsOn[0].name, 'require');
+        test.deepEqual(statement.rhs.dependsOn[0].args, [{ type: 'literal', value: 'u' } ])
         test.done();
     },
 
@@ -331,38 +242,28 @@ module.exports = {
     'udf-args': function(test) {
         var q = 'u = require("u.js");select * from patch.udf where u.p1("v1") and u.p2("2", "3") and u.p3()';
         var statement = compiler.compile(q);
-        var e = {
-                "type": "select",
-                "line": 1,
-                "fromClause": [
-                    {
-                        "name": "patch.udf"
-                    }
-                ],
-                "columns": {name: "*", type: 'column'},
-                "whereCriteria": [
-                    {
-                        "operator": "udf",
-                        "name": "u.p1",
-                        "args": [{"value": "v1", "type": "literal"}]
-                    },
-                    {
-                        "operator": "udf",
-                        "name": "u.p2",
-                        "args": [{"value": "2", "type": "literal"}, {"value": "3", "type": "literal"}],
-                    },
-                    {
-                        "operator": "udf",
-                        "name": "u.p3",
-                        "args": ""
-                    }
-                ],
-                id: 1
-            };
-        test.deepEqual(statement.rhs, e);
+        test.equals(statement.rhs.type, 'select');
+        test.deepEqual(statement.rhs.whereCriteria, [
+                            {
+                                "operator": "udf",
+                                "name": "u.p1",
+                                "args": [{"value": "v1", "type": "literal"}]
+                            },
+                            {
+                                "operator": "udf",
+                                "name": "u.p2",
+                                "args": [{"value": "2", "type": "literal"}, {"value": "3", "type": "literal"}],
+                            },
+                            {
+                                "operator": "udf",
+                                "name": "u.p3",
+                                "args": ""
+                            }
+                        ]);
+        test.equal(statement.rhs.dependsOn[0].name, 'require');
+        test.deepEqual(statement.rhs.dependsOn[0].args, [{ type: 'literal', value: 'u.js' } ])
         test.done();
     },
-
 
     'select-assign': function(test) {
         var q = 'results = select title[0], itemId[0], primaryCategory[0].categoryName[0], ' +
@@ -385,7 +286,7 @@ module.exports = {
                 dependsOn: [],
                 line: 1
             };
-        test.equals(statement.dependsOn[0].assign, 'results');
+        test.equals(statement.rhs.dependsOn[0].assign, 'results');
         test.done();
     },
 
@@ -393,22 +294,14 @@ module.exports = {
         var q = 'select title[0], \nitemId[0], primaryCategory[0].categoryName[0], ' +
             'sellingStatus[0].currentPrice[0] \nfrom ebay.finding.items';
         var statement = compiler.compile(q);
-        var e ={
-                type: 'select',
-                line: 1,
-                fromClause: [
-                    {'name': 'ebay.finding.items' }
-                ],
-                columns: [
-                    {name: 'title[0]', type: "column"},
-                    {name: 'itemId[0]', type: "column"},
-                    {name: 'primaryCategory[0].categoryName[0]', type: "column"},
-                    {name: 'sellingStatus[0].currentPrice[0]', type: "column"}
-                ],
-                whereCriteria: undefined,
-                id: 0
-            };
-        test.deepEqual(statement.rhs, e);
+        test.equal(statement.rhs.type, 'select');
+        test.deepEqual(statement.rhs.fromClause, [{'name': 'ebay.finding.items' }]);
+        test.deepEqual(statement.rhs.columns, [
+            {name: 'title[0]', type: "column"},
+            {name: 'itemId[0]', type: "column"},
+            {name: 'primaryCategory[0].categoryName[0]', type: "column"},
+            {name: 'sellingStatus[0].currentPrice[0]', type: "column"}
+        ]);
         test.done();
     },
 
@@ -782,19 +675,7 @@ module.exports = {
     'select-colon': function(test) {
         var q = 'select a:b.c:d from someXml';
         var statement = compiler.compile(q);
-        var e = {
-                type: 'select',
-                fromClause: [
-                    {'name': 'someXml' }
-                ],
-                columns: [
-                    {name: 'a:b.c:d', type: "column"}
-                ],
-                whereCriteria: undefined,
-                id: 0,
-                line: 1
-            };
-        test.deepEqual(statement.rhs, e);
+        test.equal(statement.rhs.columns[0].name, 'a:b.c:d');
         test.done();
     },
 
@@ -894,25 +775,9 @@ module.exports = {
     'select-timeouts': function(test) {
         var q = 'select a, b, c, d from foo timeout 10 minDelay 100 maxDelay 10000';
         var statement = compiler.compile(q);
-        var e = {
-                type: 'select',
-                line: 1,
-                fromClause: [
-                    {'name': 'foo' }
-                ],
-                columns: [
-                    {name: 'a', type: "column"},
-                    {name: 'b', type: "column"},
-                    {name: 'c', type: "column"},
-                    {name: 'd', type: "column"}
-                ],
-                whereCriteria: undefined,
-                timeout: 10,
-                minDelay: 100,
-                maxDelay: 10000,
-                id: 0
-            };
-        test.deepEqual(statement.rhs, e);
+        test.equal(statement.rhs.timeout, 10);
+        test.equal(statement.rhs.minDelay, 100);
+        test.equal(statement.rhs.maxDelay, 10000);
         test.done();
     }
 };

--- a/modules/compiler/test/show-test.js
+++ b/modules/compiler/test/show-test.js
@@ -21,25 +21,14 @@ var compiler = require('../lib/compiler');
 exports['show'] = function (test) {
     var q = "show tables";
     var statement = compiler.compile(q);
-    var e = {
-        type: 'show',
-        line: 1,
-        id: 0
-    };
-    test.deepEqual(statement.rhs, e);
+    test.equals(statement.rhs.type, 'show');
     test.done();
 };
-
 
 exports['show assign'] = function (test) {
     var q = "tables = show tables; return tables;";
     var statement = compiler.compile(q);
-    var e = { type: 'return',
-      line: 1,
-      id: 1,
-      rhs: { ref: 'tables' },
-      dependsOn: [ { type: 'show', line: 1, assign: 'tables', id: 0, dependsOn: [] } ] };
-    test.equal(statement.dependsOn[0].assign, 'tables');
-    test.equal(statement.dependsOn[0].listeners[0].type, 'return');
+    test.equal(statement.rhs.dependsOn[0].assign, 'tables');
+    test.equal(statement.rhs.dependsOn[0].listeners[0].type, 'ref');
     test.done();
 };

--- a/modules/compiler/test/where-udf-test.js
+++ b/modules/compiler/test/where-udf-test.js
@@ -286,13 +286,13 @@ module.exports = {
                  return select name, keys from a1 where u.toUpper()'
         var c = compiler.compile(q);
         test.equals(c.rhs.type, 'select');
-        test.equals(c.dependsOn.length, 2);
-        test.equals(c.dependsOn[1].type, 'define');
-        test.equals(c.dependsOn[1].name, 'require');
-        test.equals(c.dependsOn[1].udf, 'require');
-        test.equals(c.dependsOn[0].type, 'define');
-        test.equals(c.dependsOn[0].assign, 'a1');
-        test.equals(c.dependsOn[0].type, 'define');
+        test.equals(c.rhs.dependsOn.length, 2);
+        test.equals(c.rhs.dependsOn[1].type, 'define');
+        test.equals(c.rhs.dependsOn[1].name, 'require');
+        test.equals(c.rhs.dependsOn[1].udf, 'require');
+        test.equals(c.rhs.dependsOn[0].type, 'define');
+        test.equals(c.rhs.dependsOn[0].assign, 'a1');
+        test.equals(c.rhs.dependsOn[0].type, 'define');
 
         test.done();
     }

--- a/modules/console/package.json
+++ b/modules/console/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-console",
-    "version": "0.6.7",
+    "version": "0.6.8",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"
@@ -15,7 +15,7 @@
         "express": "2.5.9",
         "ejs": "0.7.1",
         "underscore": "1.3.3",
-        "ql.io-engine": "0.6.7",
+        "ql.io-engine": "0.6.8",
         "ql.io-mutable-uri": "0.6.3",
         "winston": "0.5.11",
         "browserify": "1.10.15",
@@ -28,7 +28,7 @@
         "xml2json": "0.2.4",
         "connect-assetmanager" : "0.0.26",
         "connect-assetmanager-handlers" : "0.0.18",
-        "ql.io-compiler": "0.6.2"
+        "ql.io-compiler": "0.6.5"
     },
     "devDependencies": {
         "nodeunit": "0.7.4",

--- a/modules/engine/lib/engine/brew.js
+++ b/modules/engine/lib/engine/brew.js
@@ -38,7 +38,7 @@ exports.go = function(options) {
     // Compile the DDL and post process
     try {
         var plan = statement || compiler.compile(script);
-        walk(options, plan);
+        walk(options, plan.rhs || plan);
     }
     catch(e) {
         console.log('Error loading ' + options.path + options.name + '.ql');

--- a/modules/engine/package.json
+++ b/modules/engine/package.json
@@ -1,7 +1,7 @@
 {
     "author": "ql.io",
     "name": "ql.io-engine",
-    "version": "0.6.7",
+    "version": "0.6.8",
     "repository": {
         "type": "git",
         "url": "https://github.com/ql-io/ql.io"
@@ -14,7 +14,7 @@
         "winston": "0.5.11",
         "underscore": "1.3.3",
         "xml2json": "https://github.com/ql-io/node-xml2json/tarball/master",
-        "ql.io-compiler": "0.6.4",
+        "ql.io-compiler": "0.6.5",
         "ql.io-mutable-uri": "0.6.3",
         "ql.io-uri-template": "0.6.2",
         "ql.io-str-template": "0.6.0",

--- a/modules/engine/test/exec-describe-routes-test.js
+++ b/modules/engine/test/exec-describe-routes-test.js
@@ -39,9 +39,9 @@ exports['describe route "/foo/bar/{selector}?userid={userId}&itemid={itemId}" us
                 test.equal(list.body.about,'/route?path=%2Ffoo%2Fbar%2F%7Bselector%7D%3Fuserid%3D%7BuserId%7D%26itemid%3D%7BitemId%7D&method=get');
                 test.ok(_.isString(list.body.info), 'list.body.info is string');
                 test.ok(_.isArray(list.body.tables), 'list.body.tables is not array');
-                test.ok(list.body.tables.length == 5 , 'Expected length = 5');
+                test.equals(list.body.tables.length, 5 , 'Expected length = 5');
                 test.ok(_.isArray(list.body.related), 'list.body.related is not array');
-                test.ok(list.body.related.length == 0 , 'Expected length = 0');
+                test.equals(list.body.related.length, 0 , 'Expected length = 0');
             }
             test.done();
         });


### PR DESCRIPTION
1. The compiler gathered all orphans as individual nodes and attached them to the return statement. With this change, the compiler gathers orphan subtrees instead.
2. The compiler registered duplicate listeners in listeners array. This caused an execution plan bloat at runtime. Now the compiler checks for duplicates.
3. The compiler used to add dependencies to the return statement and return's rhs. This caused the engine to look in both places. Now, all dependencies are added to the rhs side of the return statement.
4. Fixed more tests to avoid deepEquals on compiler output.
