### PR TITLE
fallback wait for primary

### DIFF
--- a/modules/compiler/lib/compiler.js
+++ b/modules/compiler/lib/compiler.js
@@ -136,6 +136,7 @@ function plan(compiled) {
             used.push(node.fallback.id);
             rev(node.fallback);
             node.fallback.listeners = node.listeners;
+            node.fallback.fbhold = true;
         }
     }
     used.push(ret.rhs.id);

--- a/modules/engine/lib/engine.js
+++ b/modules/engine/lib/engine.js
@@ -312,6 +312,7 @@ Engine.prototype.execute = function() {
                 todo, function(err, results) {
                     if(err) {
                         if(todo.fallback) {
+                            todo.fallback.fbhold = false;
                             return sweep(todo.fallback);
                         }
                         else {
@@ -324,6 +325,7 @@ Engine.prototype.execute = function() {
                         || results.body === null || results.body === undefined){
                         var fallback = statement.rhs ? statement.rhs.fallback : statement.fallback;
                         if(fallback) {
+                            fallback.fbhold = false;
                             return sweep(fallback);
                         }
                     }
@@ -332,9 +334,10 @@ Engine.prototype.execute = function() {
 
                     _.each(todo.listeners, function(listener) {
                         execState[listener.id].count--;
-                        sweep(listener);
+                        if (!(listener.fbhold)){
+                            sweep(listener);
+                        }
                     });
-
                     if(execState[todo.id].done) {
                         execState[todo.id].done.call(null, err, results);
                     }


### PR DESCRIPTION
problem:
With fallback's dependency added, fallback would execute parallel with primary. However, a problem can occur if the fallback finishes earlier than the primary.

change:
add a property "fbhold" in all fallbacks, hold the final step of fallback execution unless the primary fails and switches "fbhold" off. This would guarantee fallbacks wait for primary.
